### PR TITLE
Add links to rule documentation in formatter output

### DIFF
--- a/lib/formatters/stylish-fixes.js
+++ b/lib/formatters/stylish-fixes.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const SourceCodeFixer = require('eslint/lib/util/source-code-fixer')
-const table = require('text-table')
+const getRuleURI = require('eslint-rule-documentation')
 
 module.exports = function(results) {
   let output = '\n'
@@ -27,24 +27,14 @@ module.exports = function(results) {
 
     output += `${relativePath}\n`
 
-    const rows = messages.map(message => {
-      return [
-        '',
-        message.line || 0,
-        message.column || 0,
-        '',
-        message.message.replace(/\.$/, ''),
-        message.ruleId || ''
-      ]
-    })
-
-    output += table(rows, {
-      align: ['', 'r', 'l'],
-      stringLength(str) { return str.length }
-    })
-    .split('\n')
-    .map(el => el.replace(/(\d+)\s+(\d+)/, (m, p1, p2) => `${p1}:${p2}`))
-    .join('\n')
+    for (const message of messages) {
+      output += `${message.line}:${message.column} ${message.ruleId}`
+      const ruleURI = getRuleURI(message.ruleId)
+      if (ruleURI.found) {
+        output += `  (${ruleURI.url})`
+      }
+      output += `\n\t${message.message}\n`
+    }
 
     if (messages.some(msg => msg.fix)) {
       const fixResult = SourceCodeFixer.applyFixes({text: result.source}, messages)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/github/eslint-plugin-github#readme",
   "peerDependencies": {
     "eslint": ">=3.19.0",
-    "eslint-plugin-import": ">=2.2.0"
+    "eslint-plugin-import": ">=2.2.0",
+    "eslint-rule-documentation": ">=1.0.11"
   },
   "devDependencies": {
     "eslint": "^3.19.0",


### PR DESCRIPTION
Sample output:

```
app/assets/modules/github/graphs/contributors.js
1:1 github/no-flow-weak  (https://github.com/github/eslint-plugin-github/blob/master/docs/rules/no-flow-weak.md)
	Do not use Flow 'weak' mode checking, use @flow instead.
19:20 semi  (http://eslint.org/docs/rules/semi)
	Extra semicolon.
20:60 semi  (http://eslint.org/docs/rules/semi)
	Extra semicolon.
22:24 semi  (http://eslint.org/docs/rules/semi)
	Extra semicolon.
23:57 semi  (http://eslint.org/docs/rules/semi)
	Extra semicolon.
24:22 semi  (http://eslint.org/docs/rules/semi)
	Extra semicolon.
26:16 semi  (http://eslint.org/docs/rules/semi)
	Extra semicolon.
46:10 github/array-foreach  (https://github.com/github/eslint-plugin-github/blob/master/docs/rules/array-foreach.md)
	Prefer for...of instead of Array.forEach
167:5 github/array-foreach  (https://github.com/github/eslint-plugin-github/blob/master/docs/rules/array-foreach.md)
	Prefer for...of instead of Array.forEach
263:24 jquery/no-attr
	Prefer getAttribute to $.attr
309:21 jquery/no-attr
	Prefer getAttribute to $.attr


$ eslint --fix app/assets/modules/github/graphs/contributors.js
@@ -14,18 +14,18 @@
   let j
   let key
   let len
   let ref1
   let val
-  const params = {};
-  const ref = document.location.search.substr(1).split('&');
+  const params = {}
+  const ref = document.location.search.substr(1).split('&')
   for (j = 0, len = ref.length; j < len; j++) {
-    const pair = ref[j];
-    ref1 = pair.split('='), key = ref1[0], val = ref1[1];
-    params[key] = val;
+    const pair = ref[j]
+    ref1 = pair.split('='), key = ref1[0], val = ref1[1]
+    params[key] = val
   }
-  return params;
+  return params
 }
 
 function formatUTCDate(date) {
   date = new Date(date)
   return `${months[date.getUTCMonth()].slice(0, 3)} ${date.getUTCDate()}, ${date.getUTCFullYear()}`


✖ 11 problems (11 errors, 0 warnings)
```