### PR TITLE
fix: relax func-style rule; allowArrowFunctions

### DIFF
--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -10,7 +10,6 @@ module.exports = {
   },
   plugins: ['react', 'jsx-a11y', 'jest'],
   rules: {
-    'func-style': ['error', 'declaration', {allowArrowFunctions: true}],
     'jest/no-disabled-tests': 'warn',
     'jest/no-focused-tests': 'error',
     'jest/no-identical-title': 'error',

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -4,7 +4,7 @@ module.exports = {
     camelcase: ['error', {properties: 'always'}],
     'constructor-super': 'error',
     eqeqeq: ['error', 'smart'],
-    'func-style': ['error', 'declaration', {'allowArrowFunctions': true}],
+    'func-style': ['error', 'declaration', {allowArrowFunctions: true}],
     'github/no-implicit-buggy-globals': 'error',
     'github/no-sprockets-directives': 'error',
     'no-case-declarations': 'error',

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -4,7 +4,7 @@ module.exports = {
     camelcase: ['error', {properties: 'always'}],
     'constructor-super': 'error',
     eqeqeq: ['error', 'smart'],
-    'func-style': ['error', 'declaration', { 'allowArrowFunctions': true }],
+    'func-style': ['error', 'declaration', {'allowArrowFunctions': true}],
     'github/no-implicit-buggy-globals': 'error',
     'github/no-sprockets-directives': 'error',
     'no-case-declarations': 'error',

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -4,7 +4,7 @@ module.exports = {
     camelcase: ['error', {properties: 'always'}],
     'constructor-super': 'error',
     eqeqeq: ['error', 'smart'],
-    'func-style': ['error', 'declaration', { "allowArrowFunctions": true }],
+    'func-style': ['error', 'declaration', { 'allowArrowFunctions': true }],
     'github/no-implicit-buggy-globals': 'error',
     'github/no-sprockets-directives': 'error',
     'no-case-declarations': 'error',

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -4,7 +4,7 @@ module.exports = {
     camelcase: ['error', {properties: 'always'}],
     'constructor-super': 'error',
     eqeqeq: ['error', 'smart'],
-    'func-style': ['error', 'declaration'],
+    'func-style': ['error', 'declaration', { "allowArrowFunctions": true }],
     'github/no-implicit-buggy-globals': 'error',
     'github/no-sprockets-directives': 'error',
     'no-case-declarations': 'error',


### PR DESCRIPTION
This alters the func-style rule to allow for arrow functions over function declarations.

This means that `const foo = function(){}` is still invalid code, but it allows for arrow functions which have various tangiable benefits over function declarations.