### PR TITLE
Enable import/no-anonymous-default-export rule

### DIFF
--- a/lib/configs/es6.js
+++ b/lib/configs/es6.js
@@ -18,6 +18,7 @@ module.exports = {
     'import/named': 'error',
     'import/namespace': 'error',
     'import/no-absolute-path': 'error',
+    'import/no-anonymous-default-export': 'error',
     'import/no-deprecated': 'error',
     'import/no-duplicates': 'error',
     'import/no-mutable-exports': 'error',


### PR DESCRIPTION
This PR enables the [import/no-anonymous-default-export](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-anonymous-default-export.md) rule. Ensures all classes and functions exported as `default` have an explicit name for debugging purposes.

This was my other concern with allowing #24 that I couldn't think of at the time. I don't think there's a syntax to use default exports with arrow functions that are also named. (@keithamus correct me if this is something that might be resolved in future spec changes)

``` js
// syntax error
export default const foo = () => {}

// lint error from this rule
export default () => {}

// good
export default function foo() {}
```