### PR TITLE
add new config: `relay`

### DIFF
--- a/bin/eslint-github-init.js
+++ b/bin/eslint-github-init.js
@@ -7,7 +7,8 @@ const path = require('path')
 const defaults = {
   env: 'browser',
   flow: true,
-  react: true
+  react: true,
+  relay: true
 }
 
 const packagePath = path.resolve(process.cwd(), 'package.json')
@@ -15,6 +16,7 @@ if (fs.existsSync(packagePath)) {
   const packageJSON = fs.readFileSync(packagePath, 'utf8')
   defaults.flow = /flow/.test(packageJSON)
   defaults.react = /react/.test(packageJSON)
+  defaults.relay = /relay/.test(packageJSON)
 }
 
 const questions = [
@@ -33,6 +35,12 @@ const questions = [
   },
   {
     type: 'confirm',
+    name: 'relay',
+    message: 'Are you using Relay?',
+    default: defaults.relay
+  },
+  {
+    type: 'confirm',
     name: 'react',
     message: 'Are you using React?',
     default: defaults.react,
@@ -45,6 +53,7 @@ inquirer.prompt(questions).then(answers => {
   if (answers.env === 'browser') eslintrc.extends.push('plugin:github/browser')
   if (answers.flow) eslintrc.extends.push('plugin:github/flow')
   if (answers.react) eslintrc.extends.push('plugin:github/react')
+  if (answers.relay) eslintrc.extends.push('plugin:github/relay')
 
   fs.writeFileSync(path.resolve(process.cwd(), '.eslintrc.json'), JSON.stringify(eslintrc, null, '  '), 'utf8')
 

--- a/lib/configs/relay.js
+++ b/lib/configs/relay.js
@@ -1,0 +1,13 @@
+module.exports = {
+  parser: 'babel-eslint',
+  plugins: ['graphql'],
+  rules: {
+    'graphql/no-deprecated-fields': [
+      'error',
+      {
+        env: 'relay',
+        tagName: 'graphql'
+      }
+    ]
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ module.exports = {
     es6: require('./configs/es6'),
     flow: require('./configs/flow'),
     react: require('./configs/react'),
+    relay: require('./configs/relay'),
     recommended: require('./configs/recommended')
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-eslint": ">=8.0.0",
     "eslint-config-prettier": ">=2.6.0",
     "eslint-plugin-flowtype": ">=2.36.0",
+    "eslint-plugin-graphql": "^1.5.0",
     "eslint-plugin-import": ">=2.7.0",
     "eslint-plugin-jest": ">=21.0.0",
     "eslint-plugin-jsx-a11y": ">=6.0.0",


### PR DESCRIPTION
I called it `relay` rather then `graphql` and scoped it down to assume that we'd only support relay projects but if we want I can change this to take in options. I felt like doing it this way would be more "Plug-and-Play".

This patch only adds a single rule from the `eslint-plugin-graphql` package but I figured we could use this as a base and we could either add more rules in here or in subsequent PRs.

The enabled rule is the, new in 1.5.0, `graphql/no-deprecated-fields` but `eslint-plugin-grapqhl` offers many others.