### PR TITLE
add a new `no-innerText` rule

### DIFF
--- a/lib/configs/browser.js
+++ b/lib/configs/browser.js
@@ -7,7 +7,8 @@ module.exports = {
     'github/async-preventdefault': 'error',
     'github/authenticity-token': 'error',
     'github/js-class-name': 'error',
-    'github/no-dataset': 'error'
+    'github/no-dataset': 'error',
+    'github/no-innerText': 'error'
   },
   extends: [require.resolve('./recommended')]
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ module.exports = {
     'no-flow-weak': require('./rules/no-flow-weak'),
     'no-flowfixme': require('./rules/no-flowfixme'),
     'no-implicit-buggy-globals': require('./rules/no-implicit-buggy-globals'),
+    'no-innerText': require('./rules/no-innerText'),
     'no-noflow': require('./rules/no-noflow'),
     'no-sprockets-directives': require('./rules/no-sprockets-directives'),
     'no-then': require('./rules/no-then')

--- a/lib/rules/no-innerText.js
+++ b/lib/rules/no-innerText.js
@@ -1,0 +1,18 @@
+module.exports = function(context) {
+  return {
+    MemberExpression(node) {
+      if (node.property && node.property.name === 'innerText') {
+        context.report({
+          meta: {
+            fixable: 'code'
+          },
+          node: node.property,
+          message: 'Prefer textContent to innerText',
+          fix(fixer) {
+            return fixer.replaceText(node.property, 'textContent')
+          }
+        })
+      }
+    }
+  }
+}

--- a/tests/no-innerText.js
+++ b/tests/no-innerText.js
@@ -1,0 +1,37 @@
+var rule = require('../lib/rules/no-innerText')
+var RuleTester = require('eslint').RuleTester
+
+var ruleTester = new RuleTester()
+
+ruleTester.run('no-innerText', rule, {
+  valid: [
+    {
+      code: 'document.createElement("js-flash-text").textContent = "foo"'
+    },
+    {
+      code: 'document.querySelector("js-flash-text").textContent = "bar"'
+    }
+  ],
+  invalid: [
+    {
+      code: 'document.createElement("js-flash-text").innerText = "foo"',
+      errors: [
+        {
+          message: 'Prefer textContent to innerText',
+          type: 'Identifier'
+        }
+      ],
+      output: 'document.createElement("js-flash-text").textContent = "foo"'
+    },
+    {
+      code: 'document.querySelector("js-flash-text").innerText = "bar"',
+      errors: [
+        {
+          message: 'Prefer textContent to innerText',
+          type: 'Identifier'
+        }
+      ],
+      output: 'document.querySelector("js-flash-text").textContent = "bar"'
+    }
+  ]
+})


### PR DESCRIPTION
`textContent` seems like a better alternative and we seem to favor that already so if nothing else we can be consistent 😸 

```sh
$ git grep innerText | wc -l
      30
$ git grep textContent | wc -l
     235
```

There are some slight differences between the two and there is probably some code that relies on those differences but there aren't many instances so I can manually check over those to make sure nothing is breaking.

### Reading 📚  
- [`textContent` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
- [`innerText` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Node/innerText)