### PR TITLE
add `require-await` rule

### DIFF
--- a/lib/configs/app.js
+++ b/lib/configs/app.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: ['github'],
+  rules: {
+    'require-await': 'error'
+  },
+  extends: [require.resolve('./recommended')]
+}

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -58,6 +58,7 @@ module.exports = {
     'object-shorthand': ['error', 'always', {avoidQuotes: true}],
     'prefer-promise-reject-errors': 'error',
     'prettier/prettier': 'error',
+    'require-await': 'error'
     'require-yield': 'error',
     'use-isnan': 'error',
     'valid-typeof': 'error'

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -58,7 +58,6 @@ module.exports = {
     'object-shorthand': ['error', 'always', {avoidQuotes: true}],
     'prefer-promise-reject-errors': 'error',
     'prettier/prettier': 'error',
-    'require-await': 'error'
     'require-yield': 'error',
     'use-isnan': 'error',
     'valid-typeof': 'error'

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'unused-module': require('./rules/unused-module')
   },
   configs: {
+    app: require('./configs/app'),
     browser: require('./configs/browser'),
     es6: require('./configs/es6'),
     flow: require('./configs/flow'),


### PR DESCRIPTION
It makes sure that you don't have functions marked as `async` when they don't contain any `await` keywords 😄 

### 📚Reading

- [`require-await` rule documentation](https://eslint.org/docs/rules/require-await)