### PR TITLE
Separate "app" config

### DIFF
--- a/bin/eslint-github-init.js
+++ b/bin/eslint-github-init.js
@@ -5,6 +5,7 @@ const fs = require('fs')
 const path = require('path')
 
 const defaults = {
+  project: 'lib',
   env: 'browser',
   flow: true,
   react: true,
@@ -14,12 +15,20 @@ const defaults = {
 const packagePath = path.resolve(process.cwd(), 'package.json')
 if (fs.existsSync(packagePath)) {
   const packageJSON = fs.readFileSync(packagePath, 'utf8')
+  defaults.project = /private/.test(packageJSON) ? 'app' : 'lib'
   defaults.flow = /flow/.test(packageJSON)
   defaults.react = /react/.test(packageJSON)
   defaults.relay = /relay/.test(packageJSON)
 }
 
 const questions = [
+  {
+    type: 'list',
+    name: 'project',
+    message: 'Is this project a web app or reuseable library?',
+    choices: ['app', 'lib'],
+    default: defaults.project
+  },
   {
     type: 'list',
     name: 'env',
@@ -50,7 +59,13 @@ const questions = [
 
 inquirer.prompt(questions).then(answers => {
   const eslintrc = {extends: ['plugin:github/es6']}
-  if (answers.env === 'browser') eslintrc.extends.push('plugin:github/browser')
+
+  if (answers.project === 'app') {
+    eslintrc.extends.push('plugin:github/app')
+  } else if (answers.env === 'browser') {
+    eslintrc.extends.push('plugin:github/browser')
+  }
+
   if (answers.flow) eslintrc.extends.push('plugin:github/flow')
   if (answers.react) eslintrc.extends.push('plugin:github/react')
   if (answers.relay) eslintrc.extends.push('plugin:github/relay')

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -37,3 +37,7 @@ Recommended rules for projects using [React](https://reactjs.org/).
 ### `plugin:github/relay`
 
 Recommended rules for projects using [Relay](http://facebook.github.io/relay/) (and React).
+
+### `plugin:github/app`
+
+Recommended rules when writing a browser application.

--- a/lib/configs/app.js
+++ b/lib/configs/app.js
@@ -1,0 +1,10 @@
+module.exports = {
+  plugins: ['github'],
+  rules: {
+    'github/authenticity-token': 'error',
+    'github/js-class-name': 'error',
+    'github/no-dataset': 'error',
+    'github/no-then': 'error'
+  },
+  extends: [require.resolve('./recommended'), require.resolve('./es6'), require.resolve('./browser')]
+}

--- a/lib/configs/browser.js
+++ b/lib/configs/browser.js
@@ -5,9 +5,6 @@ module.exports = {
   plugins: ['github'],
   rules: {
     'github/async-preventdefault': 'error',
-    'github/authenticity-token': 'error',
-    'github/js-class-name': 'error',
-    'github/no-dataset': 'error',
     'github/no-innerText': 'error'
   },
   extends: [require.resolve('./recommended')]

--- a/lib/configs/es6.js
+++ b/lib/configs/es6.js
@@ -11,7 +11,6 @@ module.exports = {
   plugins: ['github', 'import'],
   rules: {
     'github/array-foreach': 'error',
-    'github/no-then': 'error',
     'import/default': 'error',
     'import/export': 'error',
     'import/first': 'error',

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ module.exports = {
     'unused-module': require('./rules/unused-module')
   },
   configs: {
+    app: require('./configs/app'),
     browser: require('./configs/browser'),
     es6: require('./configs/es6'),
     flow: require('./configs/flow'),


### PR DESCRIPTION
This PR introduces a breaking change that would move web application specific rules into a `github/app` config set. Other rulesets would assume a reusable library project type.