### PR TITLE
update eslint-plugin-graphql to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-eslint": ">=8.0.0",
     "eslint-config-prettier": ">=2.6.0",
     "eslint-plugin-flowtype": ">=2.36.0",
-    "eslint-plugin-graphql": ">=2.0.0",
+    "eslint-plugin-graphql": "^2.1.0",
     "eslint-plugin-import": ">=2.7.0",
     "eslint-plugin-jest": ">=21.0.0",
     "eslint-plugin-jsx-a11y": ">=6.0.0",


### PR DESCRIPTION
From the [CHANGELOG](https://github.com/apollographql/eslint-plugin-graphql/blob/master/CHANGELOG.md#v210):

- Cache schema reading/parsing results each time a rule is created in [#137](https://github.com/apollographql/eslint-plugin-graphql/pull/137) by [Kristján Oddsson](https://github.com/koddsson)

Should fix a issue where CI is running real slow for one of the internal projects.