### PR TITLE
Enable more flow rules

### DIFF
--- a/lib/configs/flow.js
+++ b/lib/configs/flow.js
@@ -5,6 +5,7 @@ module.exports = {
     'flowtype/define-flow-type': 'error',
     'flowtype/require-valid-file-annotation': ['error', 'always', {annotationStyle: 'block'}],
     'flowtype/use-flow-type': 'error',
+    'flowtype/no-weak-types': 'error',
     'github/no-flow-weak': 'error',
     'github/no-flowfixme': 'error',
     'github/no-noflow': 'error'


### PR DESCRIPTION
In order to encourage more granular type definitions I propose we enable [`flowtype/no-weak-types`](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-no-weak-types).

It shows a eslint error when someone tries to type a value as `Function` or `Object` rather then the more granular `(string) => boolean` and `{key: string}`
