### PR TITLE
upgrade eslint-plugin-flowtype to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "babel-eslint": ">=8.2.0",
     "eslint-config-prettier": ">=2.9.0",
-    "eslint-plugin-flowtype": ">=2.46.0",
+    "eslint-plugin-flowtype": "^2.49.3",
     "eslint-plugin-graphql": ">=2.1.0",
     "eslint-plugin-import": ">=2.11.0",
     "eslint-plugin-jest": ">=21.15.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "babel-eslint": ">=8.2.0",
     "eslint-config-prettier": ">=2.9.0",
-    "eslint-plugin-flowtype": "^2.49.3",
+    "eslint-plugin-flowtype": ">=2.49.3",
     "eslint-plugin-graphql": ">=2.1.0",
     "eslint-plugin-import": ">=2.11.0",
     "eslint-plugin-jest": ">=21.15.0",


### PR DESCRIPTION
We switched out our own `no-flow-fix-me-comments` rule for the one in `eslint-plugin-flowtype` in #37 but there seems to be a issue with ESLint and `no-flow-fix-me-comments`. Fortunately it was fixed [here](https://github.com/gajus/eslint-plugin-flowtype/pull/338) and has been available since version 2.49.1.

This patch updates the `eslint-plugin-flowtype` package to the latest version (2.49.3).