### PR TITLE
include `bin/*` and `lib/*` in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,10 @@
     "eslint": ">=4.19.0",
     "flow-bin": ">=0.70.0"
   },
+  "files": [
+    "bin/*",
+    "lib/*"
+  ],
   "devDependencies": {
     "eslint": "^4.8.0",
     "flow-bin": "^0.74.0",


### PR DESCRIPTION
Before we where shipping a lot of docs and tests in the package to `npm`. This patch adds the `files` property to `package.json` so that `npm` knows which files to pack and which ones to ignore.

I ran `npm pack` before and after this change and here is the diff from those two runs:

```diff
5,8d4
< npm notice 192B  .eslintrc.js
< npm notice 58B   .flowconfig
< npm notice 31B   .prettierignore
< npm notice 43B   .travis.yml
10d5
< npm notice 100B  prettier.config.js
18,30d12
< npm notice 1.1kB docs/configs.md
< npm notice 1.8kB docs/package-requirements.md
< npm notice 259B  docs/rules/array-foreach.md
< npm notice 1.5kB docs/rules/async-preventdefault.md
< npm notice 2.4kB docs/rules/authenticity-token.md
< npm notice 1.8kB docs/rules/js-class-name.md
< npm notice 228B  docs/rules/no-dataset.md
< npm notice 197B  docs/rules/no-flow-weak.md
< npm notice 19B   docs/rules/no-flowfixme.md
< npm notice 156B  docs/rules/no-noflow.md
< npm notice 632B  docs/rules/no-then.md
< npm notice 130B  docs/rules/unused-export.md
< npm notice 619B  docs/rules/unused-module.md
54,63d35
< npm notice 638B  tests/array-foreach.js
< npm notice 711B  tests/async-preventdefault.js
< npm notice 1.2kB tests/authenticity-token.js
< npm notice 3.3kB tests/js-class-name.js
< npm notice 683B  tests/no-dataset.js
< npm notice 414B  tests/no-flow-weak.js
< npm notice 2.0kB tests/no-implicit-buggy-globals.js
< npm notice 957B  tests/no-innerText.js
< npm notice 401B  tests/no-noflow.js
< npm notice 1.0kB tests/no-then.js
68,72c40,44
< npm notice package size:  16.9 kB
< npm notice unpacked size: 58.5 kB
< npm notice shasum:        80842ebf74d5ea294605faff7ffdc6e5c6d477c8
< npm notice integrity:     sha512-yXNUT2gIRJgWp[...]ahU4WjSJsHvVg==
< npm notice total files:   60
---
> npm notice package size:  10.7 kB
> npm notice unpacked size: 36.0 kB
> npm notice shasum:        b2445839294bc9ea34c860aef38ca99bfe274d38
> npm notice integrity:     sha512-1io/uwtLENZws[...]jmXOp8XH4wLWw==
> npm notice total files:   32
```

<details>
  <summary>`npm pack` before</summary>

  ```
npm notice
npm notice 📦  eslint-plugin-github@1.1.1
npm notice === Tarball Contents ===
npm notice 2.0kB package.json
npm notice 192B  .eslintrc.js
npm notice 58B   .flowconfig
npm notice 31B   .prettierignore
npm notice 43B   .travis.yml
npm notice 1.1kB LICENSE
npm notice 100B  prettier.config.js
npm notice 440B  README.md
npm notice 2.2kB bin/eslint-github-init.js
npm notice 901B  bin/eslint-ignore-errors.js
npm notice 573B  bin/eslint-unused-modules.js
npm notice 3.2kB bin/flow-coverage.js
npm notice 1.4kB bin/github-lint.js
npm notice 1.0kB bin/npm-check-github-package-requirements.js
npm notice 1.1kB docs/configs.md
npm notice 1.8kB docs/package-requirements.md
npm notice 259B  docs/rules/array-foreach.md
npm notice 1.5kB docs/rules/async-preventdefault.md
npm notice 2.4kB docs/rules/authenticity-token.md
npm notice 1.8kB docs/rules/js-class-name.md
npm notice 228B  docs/rules/no-dataset.md
npm notice 197B  docs/rules/no-flow-weak.md
npm notice 19B   docs/rules/no-flowfixme.md
npm notice 156B  docs/rules/no-noflow.md
npm notice 632B  docs/rules/no-then.md
npm notice 130B  docs/rules/unused-export.md
npm notice 619B  docs/rules/unused-module.md
npm notice 305B  lib/configs/app.js
npm notice 217B  lib/configs/browser.js
npm notice 1.1kB lib/configs/es6.js
npm notice 429B  lib/configs/flow.js
npm notice 4.3kB lib/configs/react.js
npm notice 2.0kB lib/configs/recommended.js
npm notice 210B  lib/configs/relay.js
npm notice 1.5kB lib/dependency-graph.js
npm notice 2.1kB lib/formatters/stylish-fixes.js
npm notice 1.1kB lib/index.js
npm notice 273B  lib/rules/array-foreach.js
npm notice 388B  lib/rules/async-preventdefault.js
npm notice 515B  lib/rules/authenticity-token.js
npm notice 2.8kB lib/rules/dependency-graph.js
npm notice 1.4kB lib/rules/js-class-name.js
npm notice 280B  lib/rules/no-dataset.js
npm notice 482B  lib/rules/no-flow-weak.js
npm notice 685B  lib/rules/no-implicit-buggy-globals.js
npm notice 444B  lib/rules/no-innerText.js
npm notice 475B  lib/rules/no-noflow.js
npm notice 382B  lib/rules/no-then.js
npm notice 1.4kB lib/rules/unused-export.js
npm notice 385B  lib/rules/unused-module.js
npm notice 638B  tests/array-foreach.js
npm notice 711B  tests/async-preventdefault.js
npm notice 1.2kB tests/authenticity-token.js
npm notice 3.3kB tests/js-class-name.js
npm notice 683B  tests/no-dataset.js
npm notice 414B  tests/no-flow-weak.js
npm notice 2.0kB tests/no-implicit-buggy-globals.js
npm notice 957B  tests/no-innerText.js
npm notice 401B  tests/no-noflow.js
npm notice 1.0kB tests/no-then.js
npm notice === Tarball Details ===
npm notice name:          eslint-plugin-github
npm notice version:       1.1.1
npm notice filename:      eslint-plugin-github-1.1.1.tgz
npm notice package size:  16.9 kB
npm notice unpacked size: 58.5 kB
npm notice shasum:        80842ebf74d5ea294605faff7ffdc6e5c6d477c8
npm notice integrity:     sha512-yXNUT2gIRJgWp[...]ahU4WjSJsHvVg==
npm notice total files:   60
npm notice
```
</details>

<details>
  <summary>
    `npm pack` after
  </summary>

  ```
npm notice
npm notice 📦  eslint-plugin-github@1.1.1
npm notice === Tarball Contents ===
npm notice 2.0kB package.json
npm notice 1.1kB LICENSE
npm notice 440B  README.md
npm notice 2.2kB bin/eslint-github-init.js
npm notice 901B  bin/eslint-ignore-errors.js
npm notice 573B  bin/eslint-unused-modules.js
npm notice 3.2kB bin/flow-coverage.js
npm notice 1.4kB bin/github-lint.js
npm notice 1.0kB bin/npm-check-github-package-requirements.js
npm notice 305B  lib/configs/app.js
npm notice 217B  lib/configs/browser.js
npm notice 1.1kB lib/configs/es6.js
npm notice 429B  lib/configs/flow.js
npm notice 4.3kB lib/configs/react.js
npm notice 2.0kB lib/configs/recommended.js
npm notice 210B  lib/configs/relay.js
npm notice 1.5kB lib/dependency-graph.js
npm notice 2.1kB lib/formatters/stylish-fixes.js
npm notice 1.1kB lib/index.js
npm notice 273B  lib/rules/array-foreach.js
npm notice 388B  lib/rules/async-preventdefault.js
npm notice 515B  lib/rules/authenticity-token.js
npm notice 2.8kB lib/rules/dependency-graph.js
npm notice 1.4kB lib/rules/js-class-name.js
npm notice 280B  lib/rules/no-dataset.js
npm notice 482B  lib/rules/no-flow-weak.js
npm notice 685B  lib/rules/no-implicit-buggy-globals.js
npm notice 444B  lib/rules/no-innerText.js
npm notice 475B  lib/rules/no-noflow.js
npm notice 382B  lib/rules/no-then.js
npm notice 1.4kB lib/rules/unused-export.js
npm notice 385B  lib/rules/unused-module.js
npm notice === Tarball Details ===
npm notice name:          eslint-plugin-github
npm notice version:       1.1.1
npm notice filename:      eslint-plugin-github-1.1.1.tgz
npm notice package size:  10.7 kB
npm notice unpacked size: 36.0 kB
npm notice shasum:        b2445839294bc9ea34c860aef38ca99bfe274d38
npm notice integrity:     sha512-1io/uwtLENZws[...]jmXOp8XH4wLWw==
npm notice total files:   32
npm notice
```
</details>