### PR TITLE
Add prettier.config.js to files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   },
   "files": [
     "bin/*",
-    "lib/*"
+    "lib/*",
+    "prettier.config.js"
   ],
   "devDependencies": {
     "eslint": "^4.8.0",


### PR DESCRIPTION
The latest version (1.1.2) doesn't include `prettier.config.js`, which causes instances like this to fail:

```js
// prettier.config.js
module.exports = require('eslint-plugin-github/prettier.config')
```

This adds it to the `files` field in `package.json`. :v: