### PR TITLE
Add async currentTarget rule

### DIFF
--- a/docs/rules/async-currenttarget.md
+++ b/docs/rules/async-currenttarget.md
@@ -1,0 +1,43 @@
+# `event.currentTarget` in an async function
+
+Accessing `event.currentTarget` inside an `async function()` will likely be `null` as `currentTarget` is mutated as the event is propagated.
+
+```js
+// bad
+document.addEventListener('click', async function(event) {
+  // event.currentTarget will be an HTMLElement
+  const url = event.currentTarget.getAttribute('data-url')
+  const data = await fetch(url)
+
+  // But now, event.currentTarget will be null
+  const text = event.currentTarget.getAttribute('data-text')
+  // ...
+})
+```
+
+1.  A `click` event is dispatched
+2.  The handler is invoked once with the expected `currentTarget`
+3.  An `await` defers the execution
+4.  The event dispatch continues, `event.currentTarget` is modified to point to the current target of another event handler and nulled out at the end of the dispatch
+5.  The async function resumes
+6.  `event.currentTarget` is now `null`
+
+## Solutions
+
+If you're using `async`, you'll need to synchronously create a reference to `currentTarget` before any async activity.
+
+```js
+// good
+document.addEventListener('click', function(event) {
+  const currentTarget = event.currentTarget
+  const url = currentTarget.getAttribute('data-url')
+
+  // call async IIFE
+  ;(async function() {
+    const data = await fetch(url)
+
+    const text = currentTarget.getAttribute('data-text')
+    // ...
+  })()
+})
+```

--- a/docs/rules/async-currenttarget.md
+++ b/docs/rules/async-currenttarget.md
@@ -41,3 +41,19 @@ document.addEventListener('click', function(event) {
   })()
 })
 ```
+
+Alternatively, extract a function to create an element reference.
+
+```js
+// good
+document.addEventListener('click', function(event) {
+  fetchData(event.currentTarget)
+})
+
+async function fetchData(el) {
+  const url = el.getAttribute('data-url')
+  const data = await fetch(url)
+  const text = el.getAttribute('data-text')
+  // ...
+}
+```

--- a/docs/rules/async-preventdefault.md
+++ b/docs/rules/async-preventdefault.md
@@ -12,11 +12,11 @@ document.addEventListener('click', async function(event) {
 })
 ```
 
-1. A `click` event is dispatched
-2. This handler is scheduled but not ran immediately because its marked async.
-3. The event dispatch completes and nothing has called `preventDefault()` _yet_ and the default click behavior occurs.
-4. The async function is scheduled and runs.
-5. Calling `preventDefault()` is now a no-op as the synchronous event dispatch has already completed.
+1.  A `click` event is dispatched
+2.  This handler is scheduled but not ran immediately because its marked async.
+3.  The event dispatch completes and nothing has called `preventDefault()` _yet_ and the default click behavior occurs.
+4.  The async function is scheduled and runs.
+5.  Calling `preventDefault()` is now a no-op as the synchronous event dispatch has already completed.
 
 ## Solutions
 
@@ -44,12 +44,12 @@ This could also be done with an async IIFE.
 // good
 document.addEventListener('click', function(event) {
   // preventDefault in a regular function
-  event.preventDefault()(
-    // call async IIFE
-    async function() {
-      const data = await fetch()
-      // ...
-    }
-  )()
+  event.preventDefault()
+
+  // call async IIFE
+  ;(async function() {
+    const data = await fetch()
+    // ...
+  })()
 })
 ```

--- a/lib/configs/browser.js
+++ b/lib/configs/browser.js
@@ -4,6 +4,7 @@ module.exports = {
   },
   plugins: ['github'],
   rules: {
+    'github/async-currenttarget': 'error',
     'github/async-preventdefault': 'error',
     'github/no-innerText': 'error'
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   rules: {
     'array-foreach': require('./rules/array-foreach'),
+    'async-currenttarget': require('./rules/async-currenttarget'),
     'async-preventdefault': require('./rules/async-preventdefault'),
     'authenticity-token': require('./rules/authenticity-token'),
     'dependency-graph': require('./rules/dependency-graph'),

--- a/lib/rules/async-currenttarget.js
+++ b/lib/rules/async-currenttarget.js
@@ -1,0 +1,14 @@
+module.exports = function(context) {
+  return {
+    MemberExpression(node) {
+      if (node.property && node.property.name === 'currentTarget') {
+        const scope = context.getScope()
+        if (scope.block.async) {
+          context.report(node, 'event.currentTarget inside an async function is error prone')
+        }
+      }
+    }
+  }
+}
+
+module.exports.schema = []

--- a/tests/async-currenttarget.js
+++ b/tests/async-currenttarget.js
@@ -1,0 +1,24 @@
+var rule = require('../lib/rules/async-currenttarget')
+var RuleTester = require('eslint').RuleTester
+
+var ruleTester = new RuleTester()
+
+ruleTester.run('async-currenttarget', rule, {
+  valid: [
+    {
+      code: 'document.addEventListener(function(event) { event.currentTarget })'
+    }
+  ],
+  invalid: [
+    {
+      code: 'document.addEventListener(async function(event) { await delay(); event.currentTarget })',
+      parserOptions: {ecmaVersion: 2017},
+      errors: [
+        {
+          message: 'event.currentTarget inside an async function is error prone',
+          type: 'MemberExpression'
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
Adds rule to prevent error prone access of `event.currentTarget` in async functions.

##

CC: @github/js 