### PR TITLE
Relax async rules till after first await

### DIFF
--- a/lib/rules/async-currenttarget.js
+++ b/lib/rules/async-currenttarget.js
@@ -1,9 +1,14 @@
 module.exports = function(context) {
+  const scopeDidWait = new WeakSet()
+
   return {
+    AwaitExpression() {
+      scopeDidWait.add(context.getScope(), true)
+    },
     MemberExpression(node) {
       if (node.property && node.property.name === 'currentTarget') {
         const scope = context.getScope()
-        if (scope.block.async) {
+        if (scope.block.async && scopeDidWait.has(scope)) {
           context.report(node, 'event.currentTarget inside an async function is error prone')
         }
       }

--- a/lib/rules/async-preventdefault.js
+++ b/lib/rules/async-preventdefault.js
@@ -1,9 +1,14 @@
 module.exports = function(context) {
+  const scopeDidWait = new WeakSet()
+
   return {
+    AwaitExpression() {
+      scopeDidWait.add(context.getScope(), true)
+    },
     CallExpression(node) {
       if (node.callee.property && node.callee.property.name === 'preventDefault') {
         const scope = context.getScope()
-        if (scope.block.async) {
+        if (scope.block.async && scopeDidWait.has(scope)) {
           context.report(node, 'event.preventDefault() inside an async function is error prone')
         }
       }

--- a/tests/async-currenttarget.js
+++ b/tests/async-currenttarget.js
@@ -7,6 +7,10 @@ ruleTester.run('async-currenttarget', rule, {
   valid: [
     {
       code: 'document.addEventListener(function(event) { event.currentTarget })'
+    },
+    {
+      code: 'document.addEventListener(async function(event) { event.currentTarget; await delay() })',
+      parserOptions: {ecmaVersion: 2017}
     }
   ],
   invalid: [

--- a/tests/async-preventdefault.js
+++ b/tests/async-preventdefault.js
@@ -10,11 +10,15 @@ ruleTester.run('async-preventdefault', rule, {
     },
     {
       code: 'document.addEventListener(function(event) { event.target })'
+    },
+    {
+      code: 'document.addEventListener(async function(event) { event.preventDefault() })',
+      parserOptions: {ecmaVersion: 2017}
     }
   ],
   invalid: [
     {
-      code: 'document.addEventListener(async function(event) { event.preventDefault() })',
+      code: 'document.addEventListener(async function(event) { await delay(); event.preventDefault() })',
       parserOptions: {ecmaVersion: 2017},
       errors: [
         {


### PR DESCRIPTION
Because async function are invoked synchronously, accessing `event` properties isn't dangerous until the first `await` is called which defers the remainder of the function till after a microtask.

Where before this would be flagged as a lint here, it is actually safe:

```js
on('click', '.foo', async function(event) {
  // this is safe
  event.preventDefault()

  await fetch()

  // this is the issue
  event.preventDefault()
})
```

This change relaxes the linter until after the first `await`.

But it's not bulletproof. You can imagine another case like:

```js
async function doMore(event) {
  // buggy, but won't be flagged by linter
  event.preventDefault()

  await fetchMore()
}

on('click', '.foo', async function(event) {
  await fetch()
  await doMore(event)
})
```

However, this code isn't often written. Really, checking for static symbols like `preventDefault` or `currentTarget` isn't perfect either. To really get this analysis correct, it might have to be done at the flow layer. But I think this trade-off is acceptable.