### PR TITLE
Update rules to use ESLint's new rule format

### DIFF
--- a/lib/rules/array-foreach.js
+++ b/lib/rules/array-foreach.js
@@ -1,11 +1,16 @@
-module.exports = function(context) {
-  return {
-    CallExpression(node) {
-      if (node.callee.property && node.callee.property.name === 'forEach') {
-        context.report(node, 'Prefer for...of instead of Array.forEach')
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.property && node.callee.property.name === 'forEach') {
+          context.report(node, 'Prefer for...of instead of Array.forEach')
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/lib/rules/async-currenttarget.js
+++ b/lib/rules/async-currenttarget.js
@@ -1,19 +1,24 @@
-module.exports = function(context) {
-  const scopeDidWait = new WeakSet()
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-  return {
-    AwaitExpression() {
-      scopeDidWait.add(context.getScope(), true)
-    },
-    MemberExpression(node) {
-      if (node.property && node.property.name === 'currentTarget') {
-        const scope = context.getScope()
-        if (scope.block.async && scopeDidWait.has(scope)) {
-          context.report(node, 'event.currentTarget inside an async function is error prone')
+  create(context) {
+    const scopeDidWait = new WeakSet()
+
+    return {
+      AwaitExpression() {
+        scopeDidWait.add(context.getScope(), true)
+      },
+      MemberExpression(node) {
+        if (node.property && node.property.name === 'currentTarget') {
+          const scope = context.getScope()
+          if (scope.block.async && scopeDidWait.has(scope)) {
+            context.report(node, 'event.currentTarget inside an async function is error prone')
+          }
         }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/lib/rules/async-preventdefault.js
+++ b/lib/rules/async-preventdefault.js
@@ -1,19 +1,24 @@
-module.exports = function(context) {
-  const scopeDidWait = new WeakSet()
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-  return {
-    AwaitExpression() {
-      scopeDidWait.add(context.getScope(), true)
-    },
-    CallExpression(node) {
-      if (node.callee.property && node.callee.property.name === 'preventDefault') {
-        const scope = context.getScope()
-        if (scope.block.async && scopeDidWait.has(scope)) {
-          context.report(node, 'event.preventDefault() inside an async function is error prone')
+  create(context) {
+    const scopeDidWait = new WeakSet()
+
+    return {
+      AwaitExpression() {
+        scopeDidWait.add(context.getScope(), true)
+      },
+      CallExpression(node) {
+        if (node.callee.property && node.callee.property.name === 'preventDefault') {
+          const scope = context.getScope()
+          if (scope.block.async && scopeDidWait.has(scope)) {
+            context.report(node, 'event.preventDefault() inside an async function is error prone')
+          }
         }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/lib/rules/authenticity-token.js
+++ b/lib/rules/authenticity-token.js
@@ -1,20 +1,25 @@
-module.exports = function(context) {
-  function checkAuthenticityTokenUsage(node, str) {
-    if (str.includes('authenticity_token')) {
-      context.report(
-        node,
-        'Form CSRF tokens (authenticity tokens) should not be created in JavaScript and their values should not be used directly for XHR requests.'
-      )
-    }
-  }
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-  return {
-    Literal(node) {
-      if (typeof node.value === 'string') {
-        checkAuthenticityTokenUsage(node, node.value)
+  create(context) {
+    function checkAuthenticityTokenUsage(node, str) {
+      if (str.includes('authenticity_token')) {
+        context.report(
+          node,
+          'Form CSRF tokens (authenticity tokens) should not be created in JavaScript and their values should not be used directly for XHR requests.'
+        )
+      }
+    }
+
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string') {
+          checkAuthenticityTokenUsage(node, node.value)
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/lib/rules/dependency-graph.js
+++ b/lib/rules/dependency-graph.js
@@ -5,100 +5,106 @@ const {dependencyGraph, checkEntriesWhitelist, entries} = require('../dependency
 const STAR = '*'
 const DEFAULT = 'default'
 
-module.exports = function(context) {
-  const filename = context.getFilename()
-  const sourceCode = context.getSourceCode()
+module.exports = {
+  meta: {
+    docs: {}
+  },
 
-  const imports = new Map()
-  const exports = new Set()
+  create(context) {
+    const filename = context.getFilename()
+    const sourceCode = context.getSourceCode()
 
-  checkEntriesWhitelist(filename)
+    const imports = new Map()
+    const exports = new Set()
 
-  function recordImport(filename, symbol) {
-    let symbols = imports.get(filename)
-    if (!symbols) {
-      symbols = new Set()
-      imports.set(filename, symbols)
-    }
+    checkEntriesWhitelist(filename)
 
-    if (symbol) {
-      symbols.add(symbol)
-    }
-  }
-
-  function recordExport(symbol) {
-    if (symbol) {
-      exports.add(symbol)
-    }
-  }
-
-  return {
-    ImportDeclaration(node) {
-      const resolvedPath = resolve(node.source.value, context)
-      if (!resolvedPath) {
-        return
+    function recordImport(filename, symbol) {
+      let symbols = imports.get(filename)
+      if (!symbols) {
+        symbols = new Set()
+        imports.set(filename, symbols)
       }
 
-      recordImport(resolvedPath)
+      if (symbol) {
+        symbols.add(symbol)
+      }
+    }
 
-      node.specifiers.forEach(specifier => {
-        if (specifier.type === 'ImportDefaultSpecifier') {
-          recordImport(resolvedPath, DEFAULT)
-        } else if (specifier.type === 'ImportSpecifier') {
-          recordImport(resolvedPath, specifier.imported.name)
+    function recordExport(symbol) {
+      if (symbol) {
+        exports.add(symbol)
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        const resolvedPath = resolve(node.source.value, context)
+        if (!resolvedPath) {
+          return
         }
-      })
-    },
-    ExportDefaultDeclaration() {
-      recordExport(DEFAULT)
-    },
-    ExportNamedDeclaration(node) {
-      if (node.declaration == null) return
 
-      if (node.declaration.id != null) {
-        recordExport(node.declaration.id.name)
-      }
+        recordImport(resolvedPath)
 
-      if (node.declaration.declarations != null) {
-        for (const declaration of node.declaration.declarations) {
-          recordExport(declaration.id.name)
+        node.specifiers.forEach(specifier => {
+          if (specifier.type === 'ImportDefaultSpecifier') {
+            recordImport(resolvedPath, DEFAULT)
+          } else if (specifier.type === 'ImportSpecifier') {
+            recordImport(resolvedPath, specifier.imported.name)
+          }
+        })
+      },
+      ExportDefaultDeclaration() {
+        recordExport(DEFAULT)
+      },
+      ExportNamedDeclaration(node) {
+        if (node.declaration == null) return
+
+        if (node.declaration.id != null) {
+          recordExport(node.declaration.id.name)
         }
-      }
-    },
-    CallExpression(node) {
-      if (node.callee.type === 'Identifier' && node.callee.name === 'require' && node.arguments.length === 1) {
-        const pathNode = node.arguments[0]
-        if (pathNode.type === 'Literal' && typeof pathNode.value === 'string') {
-          const resolvedPath =
-            pathNode.type === 'Literal' && typeof pathNode.value === 'string' && resolve(pathNode.value, context)
 
-          if (resolvedPath) {
-            recordImport(resolvedPath, STAR)
+        if (node.declaration.declarations != null) {
+          for (const declaration of node.declaration.declarations) {
+            recordExport(declaration.id.name)
           }
         }
-      }
-    },
-    MemberExpression(node) {
-      if (context.getScope().type !== 'module') {
-        return
-      }
+      },
+      CallExpression(node) {
+        if (node.callee.type === 'Identifier' && node.callee.name === 'require' && node.arguments.length === 1) {
+          const pathNode = node.arguments[0]
+          if (pathNode.type === 'Literal' && typeof pathNode.value === 'string') {
+            const resolvedPath =
+              pathNode.type === 'Literal' && typeof pathNode.value === 'string' && resolve(pathNode.value, context)
 
-      if (node.object.name === 'module' && node.property.name === 'exports') {
-        recordExport(DEFAULT)
-      }
+            if (resolvedPath) {
+              recordImport(resolvedPath, STAR)
+            }
+          }
+        }
+      },
+      MemberExpression(node) {
+        if (context.getScope().type !== 'module') {
+          return
+        }
 
-      if (node.object.name === 'exports') {
-        recordExport(node.property.name)
+        if (node.object.name === 'module' && node.property.name === 'exports') {
+          recordExport(DEFAULT)
+        }
+
+        if (node.object.name === 'exports') {
+          recordExport(node.property.name)
+        }
+      },
+      Program() {
+        const comments = sourceCode.getAllComments()
+        if (comments.some(token => token.type === 'Shebang')) {
+          entries.add(filename)
+        }
+      },
+      'Program:exit': function() {
+        dependencyGraph.set(filename, {imports, exports})
       }
-    },
-    Program() {
-      const comments = sourceCode.getAllComments()
-      if (comments.some(token => token.type === 'Shebang')) {
-        entries.add(filename)
-      }
-    },
-    'Program:exit': function() {
-      dependencyGraph.set(filename, {imports, exports})
     }
   }
 }

--- a/lib/rules/js-class-name.js
+++ b/lib/rules/js-class-name.js
@@ -1,48 +1,53 @@
-module.exports = function(context) {
-  var allJsClassNameRegexp = /\bjs-[_a-zA-Z0-9-]*/g
-  var validJsClassNameRegexp = /^js(-[a-z0-9]+)+$/g
-  var endWithJsClassNameRegexp = /\bjs-[_a-zA-Z0-9-]*$/g
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-  function checkStringFormat(node, str) {
-    var matches = str.match(allJsClassNameRegexp) || []
-    matches.forEach(function(match) {
-      if (!match.match(validJsClassNameRegexp)) {
-        context.report(node, 'js- class names should be lowercase and only contain dashes.')
-      }
-    })
-  }
+  create(context) {
+    var allJsClassNameRegexp = /\bjs-[_a-zA-Z0-9-]*/g
+    var validJsClassNameRegexp = /^js(-[a-z0-9]+)+$/g
+    var endWithJsClassNameRegexp = /\bjs-[_a-zA-Z0-9-]*$/g
 
-  function checkStringEndsWithJSClassName(node, str) {
-    if (str.match(endWithJsClassNameRegexp)) {
-      context.report(node, 'js- class names should be statically defined.')
-    }
-  }
-
-  return {
-    Literal(node) {
-      if (typeof node.value === 'string') {
-        checkStringFormat(node, node.value)
-
-        if (
-          node.parent &&
-          node.parent.type === 'BinaryExpression' &&
-          node.parent.operator === '+' &&
-          node.parent.left.value
-        ) {
-          checkStringEndsWithJSClassName(node.parent.left, node.parent.left.value)
-        }
-      }
-    },
-    TemplateLiteral(node) {
-      node.quasis.forEach(function(quasi) {
-        checkStringFormat(quasi, quasi.value.raw)
-
-        if (quasi.tail === false) {
-          checkStringEndsWithJSClassName(quasi, quasi.value.raw)
+    function checkStringFormat(node, str) {
+      var matches = str.match(allJsClassNameRegexp) || []
+      matches.forEach(function(match) {
+        if (!match.match(validJsClassNameRegexp)) {
+          context.report(node, 'js- class names should be lowercase and only contain dashes.')
         }
       })
     }
+
+    function checkStringEndsWithJSClassName(node, str) {
+      if (str.match(endWithJsClassNameRegexp)) {
+        context.report(node, 'js- class names should be statically defined.')
+      }
+    }
+
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string') {
+          checkStringFormat(node, node.value)
+
+          if (
+            node.parent &&
+            node.parent.type === 'BinaryExpression' &&
+            node.parent.operator === '+' &&
+            node.parent.left.value
+          ) {
+            checkStringEndsWithJSClassName(node.parent.left, node.parent.left.value)
+          }
+        }
+      },
+      TemplateLiteral(node) {
+        node.quasis.forEach(function(quasi) {
+          checkStringFormat(quasi, quasi.value.raw)
+
+          if (quasi.tail === false) {
+            checkStringEndsWithJSClassName(quasi, quasi.value.raw)
+          }
+        })
+      }
+    }
   }
 }
-
-module.exports.schema = []

--- a/lib/rules/no-dataset.js
+++ b/lib/rules/no-dataset.js
@@ -1,11 +1,16 @@
-module.exports = function(context) {
-  return {
-    MemberExpression(node) {
-      if (node.property && node.property.name === 'dataset') {
-        context.report(node, "Use getAttribute('data-your-attribute') instead of dataset.")
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
+
+  create(context) {
+    return {
+      MemberExpression(node) {
+        if (node.property && node.property.name === 'dataset') {
+          context.report(node, "Use getAttribute('data-your-attribute') instead of dataset.")
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/lib/rules/no-flow-weak.js
+++ b/lib/rules/no-flow-weak.js
@@ -1,19 +1,24 @@
-module.exports = function(context) {
-  function handleComment(comment) {
-    var value = comment.value.trim()
-    if (value.match(/@flow weak/)) {
-      context.report(comment, "Do not use Flow 'weak' mode checking, use @flow instead.")
-    }
-  }
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-  return {
-    LineComment: handleComment,
-    BlockComment: handleComment,
-    Program() {
-      const comments = context.getSourceCode().getAllComments()
-      comments.forEach(handleComment)
+  create(context) {
+    function handleComment(comment) {
+      var value = comment.value.trim()
+      if (value.match(/@flow weak/)) {
+        context.report(comment, "Do not use Flow 'weak' mode checking, use @flow instead.")
+      }
+    }
+
+    return {
+      LineComment: handleComment,
+      BlockComment: handleComment,
+      Program() {
+        const comments = context.getSourceCode().getAllComments()
+        comments.forEach(handleComment)
+      }
     }
   }
 }
-
-module.exports.schema = []

--- a/lib/rules/no-implicit-buggy-globals.js
+++ b/lib/rules/no-implicit-buggy-globals.js
@@ -1,26 +1,31 @@
-module.exports = function(context) {
-  return {
-    Program() {
-      var scope = context.getScope()
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      scope.variables.forEach(function(variable) {
-        if (variable.writeable) {
-          return
-        }
+  create(context) {
+    return {
+      Program() {
+        var scope = context.getScope()
 
-        variable.defs.forEach(function(def) {
-          if (
-            def.type === 'FunctionName' ||
-            def.type === 'ClassName' ||
-            (def.type === 'Variable' && def.parent.kind === 'const') ||
-            (def.type === 'Variable' && def.parent.kind === 'let')
-          ) {
-            context.report(def.node, 'Implicit global variable, assign as global property instead.')
+        scope.variables.forEach(function(variable) {
+          if (variable.writeable) {
+            return
           }
+
+          variable.defs.forEach(function(def) {
+            if (
+              def.type === 'FunctionName' ||
+              def.type === 'ClassName' ||
+              (def.type === 'Variable' && def.parent.kind === 'const') ||
+              (def.type === 'Variable' && def.parent.kind === 'let')
+            ) {
+              context.report(def.node, 'Implicit global variable, assign as global property instead.')
+            }
+          })
         })
-      })
+      }
     }
   }
 }
-
-module.exports.schema = []

--- a/lib/rules/no-innerText.js
+++ b/lib/rules/no-innerText.js
@@ -1,17 +1,24 @@
-module.exports = function(context) {
-  return {
-    MemberExpression(node) {
-      if (node.property && node.property.name === 'innerText') {
-        context.report({
-          meta: {
-            fixable: 'code'
-          },
-          node: node.property,
-          message: 'Prefer textContent to innerText',
-          fix(fixer) {
-            return fixer.replaceText(node.property, 'textContent')
-          }
-        })
+module.exports = {
+  meta: {
+    docs: {},
+    fixable: 'code'
+  },
+
+  create(context) {
+    return {
+      MemberExpression(node) {
+        if (node.property && node.property.name === 'innerText') {
+          context.report({
+            meta: {
+              fixable: 'code'
+            },
+            node: node.property,
+            message: 'Prefer textContent to innerText',
+            fix(fixer) {
+              return fixer.replaceText(node.property, 'textContent')
+            }
+          })
+        }
       }
     }
   }

--- a/lib/rules/no-noflow.js
+++ b/lib/rules/no-noflow.js
@@ -1,19 +1,24 @@
-module.exports = function(context) {
-  function handleComment(comment) {
-    var value = comment.value.trim()
-    if (value.match(/@noflow/)) {
-      context.report(comment, 'Do not disable Flow type checker, use @flow instead.')
-    }
-  }
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-  return {
-    LineComment: handleComment,
-    BlockComment: handleComment,
-    Program() {
-      const comments = context.getSourceCode().getAllComments()
-      comments.forEach(handleComment)
+  create(context) {
+    function handleComment(comment) {
+      var value = comment.value.trim()
+      if (value.match(/@noflow/)) {
+        context.report(comment, 'Do not disable Flow type checker, use @flow instead.')
+      }
+    }
+
+    return {
+      LineComment: handleComment,
+      BlockComment: handleComment,
+      Program() {
+        const comments = context.getSourceCode().getAllComments()
+        comments.forEach(handleComment)
+      }
     }
   }
 }
-
-module.exports.schema = []

--- a/lib/rules/no-then.js
+++ b/lib/rules/no-then.js
@@ -1,10 +1,16 @@
-module.exports = function(context) {
-  return {
-    MemberExpression(node) {
-      if (node.property && node.property.name === 'then') {
-        context.report(node.property, 'Prefer async/await to Promise.then()')
-      } else if (node.property && node.property.name === 'catch') {
-        context.report(node.property, 'Prefer async/await to Promise.catch()')
+module.exports = {
+  meta: {
+    docs: {}
+  },
+
+  create(context) {
+    return {
+      MemberExpression(node) {
+        if (node.property && node.property.name === 'then') {
+          context.report(node.property, 'Prefer async/await to Promise.then()')
+        } else if (node.property && node.property.name === 'catch') {
+          context.report(node.property, 'Prefer async/await to Promise.catch()')
+        }
       }
     }
   }

--- a/lib/rules/unused-export.js
+++ b/lib/rules/unused-export.js
@@ -1,48 +1,54 @@
 const {entries, imported} = require('../dependency-graph')
 
-module.exports = function(context) {
-  const filename = context.getFilename()
-  const {identifiers} = imported()
+module.exports = {
+  meta: {
+    docs: {}
+  },
 
-  if (entries.has(filename)) {
-    return {}
-  }
+  create(context) {
+    const filename = context.getFilename()
+    const {identifiers} = imported()
 
-  if (identifiers.has(`${filename}#*`)) {
-    return {}
-  }
+    if (entries.has(filename)) {
+      return {}
+    }
 
-  return {
-    ExportDefaultDeclaration(node) {
-      if (!identifiers.has(`${filename}#default`)) {
-        context.report(node, 'Export was not imported by any modules.')
-      }
-    },
-    ExportNamedDeclaration(node) {
-      if (node.declaration == null) return
+    if (identifiers.has(`${filename}#*`)) {
+      return {}
+    }
 
-      if (node.declaration.id != null) {
-        if (!identifiers.has(`${filename}#${node.declaration.id.name}`)) {
+    return {
+      ExportDefaultDeclaration(node) {
+        if (!identifiers.has(`${filename}#default`)) {
           context.report(node, 'Export was not imported by any modules.')
         }
-      }
+      },
+      ExportNamedDeclaration(node) {
+        if (node.declaration == null) return
 
-      if (node.declaration.declarations != null) {
-        for (const declaration of node.declaration.declarations) {
-          if (!identifiers.has(`${filename}#${declaration.id.name}`)) {
+        if (node.declaration.id != null) {
+          if (!identifiers.has(`${filename}#${node.declaration.id.name}`)) {
             context.report(node, 'Export was not imported by any modules.')
           }
         }
-      }
-    },
-    MemberExpression(node) {
-      if (context.getScope().type !== 'module') {
-        return
-      }
 
-      if (node.object.name === 'exports') {
-        if (!identifiers.has(`${filename}#${node.property.name}`)) {
-          context.report(node.parent, 'Export was not imported by any modules.')
+        if (node.declaration.declarations != null) {
+          for (const declaration of node.declaration.declarations) {
+            if (!identifiers.has(`${filename}#${declaration.id.name}`)) {
+              context.report(node, 'Export was not imported by any modules.')
+            }
+          }
+        }
+      },
+      MemberExpression(node) {
+        if (context.getScope().type !== 'module') {
+          return
+        }
+
+        if (node.object.name === 'exports') {
+          if (!identifiers.has(`${filename}#${node.property.name}`)) {
+            context.report(node.parent, 'Export was not imported by any modules.')
+          }
         }
       }
     }

--- a/lib/rules/unused-module.js
+++ b/lib/rules/unused-module.js
@@ -1,17 +1,23 @@
 const {entries, imported} = require('../dependency-graph')
 
-module.exports = function(context) {
-  const filename = context.getFilename()
+module.exports = {
+  meta: {
+    docs: {}
+  },
 
-  if (entries.has(filename)) {
-    return {}
-  }
+  create(context) {
+    const filename = context.getFilename()
 
-  return {
-    Program(node) {
-      const {filenames} = imported()
-      if (!filenames.has(filename)) {
-        context.report(node, 'Module was not imported by any files.')
+    if (entries.has(filename)) {
+      return {}
+    }
+
+    return {
+      Program(node) {
+        const {filenames} = imported()
+        if (!filenames.has(filename)) {
+          context.report(node, 'Module was not imported by any files.')
+        }
       }
     }
   }


### PR DESCRIPTION
ESLint introduced a "new rule format" back in 2016 (see [this blog post](https://eslint.org/blog/2016/07/eslint-new-rule-format)), which changes the rule format from this:

```js
module.exports = function(context) {}
module.exports.schema = []
```

to this:

```js
module.exports = {
  meta: {
    docs: {},
    schema: [],
  },
  create(context) {},
}
```

ESLint provides a [codemod to switch to this new format](https://github.com/eslint/eslint-transforms#new-rule-format), which I used to make the changes in this PR. The diff is a little noisy due to whitespace changes, so please append `?w=1` to your URL to ignore whitespace changes to get a clearer sense of what has changed.

I don't think the old rule format is necessarily at risk for being unsupported, at least not that I can find in searching online, but was browsing the source of this plugin and noticed that this could be updated with a codemod across all rules. Hope this is useful to you - thanks! 🙂