### PR TITLE
Prefer lowercase HTML attribute names

### DIFF
--- a/docs/rules/get-attribute.md
+++ b/docs/rules/get-attribute.md
@@ -1,0 +1,13 @@
+# getAttribute
+
+As HTML attributes are case insensitive, prefer using lowercase.
+
+```js
+// bad
+el.getAttribute('autoComplete')
+el.getAttribute('dataFoo')
+
+// good
+el.getAttribute('autocomplete')
+el.getAttribute('data-foo')
+```

--- a/lib/rules/get-attribute.js
+++ b/lib/rules/get-attribute.js
@@ -1,0 +1,29 @@
+module.exports = function(context) {
+  const attributeCalls = /^(get|has|set|remove)Attribute$/
+  const validAttributeName = /^[a-z][a-z-]*$/
+
+  return {
+    CallExpression(node) {
+      if (!node.callee.property) return
+
+      const calleeName = node.callee.property.name
+      if (!attributeCalls.test(calleeName)) return
+
+      const attributeNameNode = node.arguments[0]
+      if (!attributeNameNode) return
+
+      if (!validAttributeName.test(attributeNameNode.value)) {
+        context.report({
+          meta: {
+            fixable: 'code'
+          },
+          node: attributeNameNode,
+          message: 'Attributes should be lowercase and hyphen separated.',
+          fix(fixer) {
+            return fixer.replaceText(attributeNameNode, `'${attributeNameNode.value.toLowerCase()}'`)
+          }
+        })
+      }
+    }
+  }
+}

--- a/tests/get-attribute.js
+++ b/tests/get-attribute.js
@@ -1,0 +1,46 @@
+var rule = require('../lib/rules/get-attribute')
+var RuleTester = require('eslint').RuleTester
+
+var ruleTester = new RuleTester()
+
+ruleTester.run('get-attribute', rule, {
+  valid: [
+    {code: "el.getAttribute('src')"},
+    {code: "el.hasAttribute('src')"},
+    {code: "el.setAttribute('src', 'https://github.com/')"},
+    {code: "el.removeAttribute('src')"},
+    {code: "el.getAttribute('data-foo')"},
+    {code: "el.hasAttribute('data-foo')"},
+    {code: "el.setAttribute('data-foo', 'bar')"},
+    {code: "el.removeAttribute('data-foo')"}
+  ],
+  invalid: [
+    {
+      code: "el.getAttribute('SRC')",
+      errors: [
+        {
+          message: 'Attributes should be lowercase and hyphen separated.',
+          type: 'Literal'
+        }
+      ]
+    },
+    {
+      code: "el.hasAttribute('SRC')",
+      errors: [
+        {
+          message: 'Attributes should be lowercase and hyphen separated.',
+          type: 'Literal'
+        }
+      ]
+    },
+    {
+      code: "el.getAttribute('onClick')",
+      errors: [
+        {
+          message: 'Attributes should be lowercase and hyphen separated.',
+          type: 'Literal'
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
Ensures general consistency for accessing known attributes as well as encouraging hyphens over underscores (or whatever people come up with) for custom attributes.