### PR TITLE
Lint against unescaped html literals

### DIFF
--- a/docs/rules/unescaped-html-literal.md
+++ b/docs/rules/unescaped-html-literal.md
@@ -1,0 +1,21 @@
+# Avoid unescaped HTML string literals
+
+Constructing raw HTML with string literals is error prone and may lead to security issues.
+
+Instead use [`lit-html`](https://github.com/Polymer/lit-html)'s `html` tagged template literal to safely construct HTML literal strings. Alternatively, you can use document builder APIs like `document.createElement`.
+
+```js
+// bad
+const title = `<h1>Hello ${name}!</h1>`
+
+// good
+const title = html`<h1>Hello ${name}!</h1>`
+
+// also good
+const title = document.createElement('h1')
+title.textContent = `Hello ${name}!`
+```
+
+## See Also
+
+https://github.com/Polymer/lit-html

--- a/lib/configs/browser.js
+++ b/lib/configs/browser.js
@@ -7,7 +7,8 @@ module.exports = {
     'github/async-currenttarget': 'error',
     'github/async-preventdefault': 'error',
     'github/get-attribute': 'error',
-    'github/no-innerText': 'error'
+    'github/no-innerText': 'error',
+    'github/unescaped-html-literal': 'error'
   },
   extends: [require.resolve('./recommended')]
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ module.exports = {
     'no-innerText': require('./rules/no-innerText'),
     'no-noflow': require('./rules/no-noflow'),
     'no-then': require('./rules/no-then'),
+    'unescaped-html-literal': require('./rules/unescaped-html-literal'),
     'unused-export': require('./rules/unused-export'),
     'unused-module': require('./rules/unused-module')
   },

--- a/lib/rules/unescaped-html-literal.js
+++ b/lib/rules/unescaped-html-literal.js
@@ -1,0 +1,25 @@
+module.exports = function(context) {
+  const htmlOpenTag = /<[a-zA-Z]/
+  const message = 'Unescaped HTML literal. Use html`` tag template literal for secure escaping.'
+
+  return {
+    Literal(node) {
+      if (!htmlOpenTag.test(node.value)) return
+
+      context.report({
+        node,
+        message
+      })
+    },
+    TemplateLiteral(node) {
+      if (!htmlOpenTag.test(node.quasis[0].value.raw)) return
+
+      if (!node.parent.tag || node.parent.tag.name !== 'html') {
+        context.report({
+          node,
+          message
+        })
+      }
+    }
+  }
+}

--- a/lib/rules/unescaped-html-literal.js
+++ b/lib/rules/unescaped-html-literal.js
@@ -1,5 +1,5 @@
 module.exports = function(context) {
-  const htmlOpenTag = /<[a-zA-Z]/
+  const htmlOpenTag = /^<[a-zA-Z]/
   const message = 'Unescaped HTML literal. Use html`` tag template literal for secure escaping.'
 
   return {

--- a/tests/unescaped-html-literal.js
+++ b/tests/unescaped-html-literal.js
@@ -1,0 +1,71 @@
+var rule = require('../lib/rules/unescaped-html-literal')
+var RuleTester = require('eslint').RuleTester
+
+var ruleTester = new RuleTester()
+
+ruleTester.run('unescaped-html-literal', rule, {
+  valid: [
+    {
+      code: '`Hello World!`;',
+      parserOptions: {ecmaVersion: 2017}
+    },
+    {
+      code: "'Hello World!'",
+      parserOptions: {ecmaVersion: 2017}
+    },
+    {
+      code: '"Hello World!"',
+      parserOptions: {ecmaVersion: 2017}
+    },
+    {
+      code: 'const helloTemplate = () => html`<div>Hello World!</div>`;',
+      parserOptions: {ecmaVersion: 2017}
+    },
+    {
+      code: 'const helloTemplate = (name) => html`<div>Hello ${name}!</div>`;',
+      parserOptions: {ecmaVersion: 2017}
+    }
+  ],
+  invalid: [
+    {
+      code: "const helloHTML = '<div>Hello, World!</div>'",
+      parserOptions: {ecmaVersion: 2017},
+      errors: [
+        {
+          message: 'Unescaped HTML literal. Use html`` tag template literal for secure escaping.',
+          type: 'Literal'
+        }
+      ]
+    },
+    {
+      code: 'const helloHTML = "<h1>Hello, World!</h1>"',
+      parserOptions: {ecmaVersion: 2017},
+      errors: [
+        {
+          message: 'Unescaped HTML literal. Use html`` tag template literal for secure escaping.',
+          type: 'Literal'
+        }
+      ]
+    },
+    {
+      code: 'const helloHTML = `<div>Hello ${name}!</div>`',
+      parserOptions: {ecmaVersion: 2017},
+      errors: [
+        {
+          message: 'Unescaped HTML literal. Use html`` tag template literal for secure escaping.',
+          type: 'TemplateLiteral'
+        }
+      ]
+    },
+    {
+      code: 'const helloHTML = foo`<div>Hello ${name}!</div>`',
+      parserOptions: {ecmaVersion: 2017},
+      errors: [
+        {
+          message: 'Unescaped HTML literal. Use html`` tag template literal for secure escaping.',
+          type: 'TemplateLiteral'
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
Pushing developers towards [lit-html](https://github.com/Polymer/lit-html) over unescaped raw HTML literals.

This initial implementation is pretty simple, it's just checking to see if the string starts with an HTML opening tag. I don't know how sophisticated we want to get. Concerned about false positives. Maybe we can start with this dumb check and improve it as we find real world examples that miss the linter.

##

CC: @github/appsec how this will make you 😄 