### PR TITLE
Add valid camelCase SVG attribute whitelist (and lowercase blacklist)

### DIFF
--- a/lib/rules/get-attribute.js
+++ b/lib/rules/get-attribute.js
@@ -3,7 +3,7 @@ module.exports = function(context) {
   const validAttributeName = /^[a-z][a-z0-9-]*$/
   // these are common SVG attributes that *must* have the correct case to work
   const attributeWhitelist = new Set(['clipPath', 'preserveAspectRatio', 'viewBox'])
-  
+
   function isValidAttribute(name) {
     return attributeWhitelist.has(name) || validAttributeName.test(name)
   }

--- a/lib/rules/get-attribute.js
+++ b/lib/rules/get-attribute.js
@@ -2,14 +2,10 @@ module.exports = function(context) {
   const attributeCalls = /^(get|has|set|remove)Attribute$/
   const validAttributeName = /^[a-z][a-z0-9-]*$/
   // these are common SVG attributes that *must* have the correct case to work
-  const attributeWhitelist = new Set([
-    'clipPath',
-    'preserveAspectRatio',
-    'viewBox'
-  ])
+  const attributeWhitelist = new Set(['clipPath', 'preserveAspectRatio', 'viewBox'])
   
   function isValidAttribute(name) {
-    return attributeWhitelist.contains(name) || validAttributeName.test(name)
+    return attributeWhitelist.has(name) || validAttributeName.test(name)
   }
 
   return {

--- a/lib/rules/get-attribute.js
+++ b/lib/rules/get-attribute.js
@@ -1,13 +1,23 @@
+const svgElementAttributes = require('svg-element-attributes')
+
+const attributeCalls = /^(get|has|set|remove)Attribute$/
+const validAttributeName = /^[a-z][a-z0-9-]*$/
+
+// these are common SVG attributes that *must* have the correct case to work
+const camelCaseAttributes = Object.values(svgElementAttributes)
+  .reduce((all, elementAttrs) => all.concat(elementAttrs), [])
+  .filter(name => !validAttributeName.test(name))
+
+const validSVGAttributeSet = new Set(camelCaseAttributes)
+
+// lowercase variants of camelCase SVG attributes are probably an error
+const invalidSVGAttributeSet = new Set(camelCaseAttributes.map(name => name.toLowerCase()))
+
+function isValidAttribute(name) {
+  return validSVGAttributeSet.has(name) || (validAttributeName.test(name) && !invalidSVGAttributeSet.has(name))
+}
+
 module.exports = function(context) {
-  const attributeCalls = /^(get|has|set|remove)Attribute$/
-  const validAttributeName = /^[a-z][a-z0-9-]*$/
-  // these are common SVG attributes that *must* have the correct case to work
-  const attributeWhitelist = new Set(['clipPath', 'preserveAspectRatio', 'viewBox'])
-
-  function isValidAttribute(name) {
-    return attributeWhitelist.has(name) || validAttributeName.test(name)
-  }
-
   return {
     CallExpression(node) {
       if (!node.callee.property) return
@@ -24,7 +34,7 @@ module.exports = function(context) {
             fixable: 'code'
           },
           node: attributeNameNode,
-          message: 'Attributes should be lowercase and hyphen separated.',
+          message: 'Attributes should be lowercase and hyphen separated, or part of the SVG whitelist.',
           fix(fixer) {
             return fixer.replaceText(attributeNameNode, `'${attributeNameNode.value.toLowerCase()}'`)
           }

--- a/lib/rules/get-attribute.js
+++ b/lib/rules/get-attribute.js
@@ -1,6 +1,16 @@
 module.exports = function(context) {
   const attributeCalls = /^(get|has|set|remove)Attribute$/
   const validAttributeName = /^[a-z][a-z0-9-]*$/
+  // these are common SVG attributes that *must* have the correct case to work
+  const attributeWhitelist = new Set([
+    'clipPath',
+    'preserveAspectRatio',
+    'viewBox'
+  ])
+  
+  function isValidAttribute(name) {
+    return attributeWhitelist.contains(name) || validAttributeName.test(name)
+  }
 
   return {
     CallExpression(node) {
@@ -12,7 +22,7 @@ module.exports = function(context) {
       const attributeNameNode = node.arguments[0]
       if (!attributeNameNode) return
 
-      if (!validAttributeName.test(attributeNameNode.value)) {
+      if (!isValidAttribute(attributeNameNode.value)) {
         context.report({
           meta: {
             fixable: 'code'

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "eslint-rule-documentation": ">=1.0.0",
     "inquirer": "^6.0.0",
     "prettier": ">=1.12.0",
-    "read-pkg-up": "^4.0.0"
+    "read-pkg-up": "^4.0.0",
+    "svg-element-attributes": "^1.2.1"
   },
   "peerDependencies": {
     "eslint": ">=4.19.0",

--- a/tests/get-attribute.js
+++ b/tests/get-attribute.js
@@ -13,7 +13,10 @@ ruleTester.run('get-attribute', rule, {
     {code: "el.hasAttribute('data-foo')"},
     {code: "el.setAttribute('data-foo', 'bar')"},
     {code: "el.removeAttribute('data-foo')"},
-    {code: "el.getAttribute('data-foo1')"}
+    {code: "el.getAttribute('data-foo1')"},
+    // some SVG attributes must preserve case
+    {code: "el.getAttribute('preserveAspectRatio')"},
+    {code: "el.getAttribute('viewBox')"}
   ],
   invalid: [
     {

--- a/tests/get-attribute.js
+++ b/tests/get-attribute.js
@@ -23,7 +23,7 @@ ruleTester.run('get-attribute', rule, {
       code: "el.getAttribute('SRC')",
       errors: [
         {
-          message: 'Attributes should be lowercase and hyphen separated.',
+          message: 'Attributes should be lowercase and hyphen separated, or part of the SVG whitelist.',
           type: 'Literal'
         }
       ]
@@ -32,7 +32,7 @@ ruleTester.run('get-attribute', rule, {
       code: "el.hasAttribute('SRC')",
       errors: [
         {
-          message: 'Attributes should be lowercase and hyphen separated.',
+          message: 'Attributes should be lowercase and hyphen separated, or part of the SVG whitelist.',
           type: 'Literal'
         }
       ]
@@ -41,7 +41,25 @@ ruleTester.run('get-attribute', rule, {
       code: "el.getAttribute('onClick')",
       errors: [
         {
-          message: 'Attributes should be lowercase and hyphen separated.',
+          message: 'Attributes should be lowercase and hyphen separated, or part of the SVG whitelist.',
+          type: 'Literal'
+        }
+      ]
+    },
+    {
+      code: "el.getAttribute('viewbox')",
+      errors: [
+        {
+          message: 'Attributes should be lowercase and hyphen separated, or part of the SVG whitelist.',
+          type: 'Literal'
+        }
+      ]
+    },
+    {
+      code: "el.getAttribute('preserveaspectratio')",
+      errors: [
+        {
+          message: 'Attributes should be lowercase and hyphen separated, or part of the SVG whitelist.',
           type: 'Literal'
         }
       ]


### PR DESCRIPTION
This adds an whitelist for SVG attribute names that _must_ be specified in the correct case, such as `clipPath`, `preserveAspectRatio`, and `viewBox`, collected from [`svg-element-attributes`](https://github.com/wooorm/svg-element-attributes/blob/master/index.json). Because we can't reliably detect which element names the code is calling attribute methods on, only whitelist attributes that don't match the `validAttributeName` pattern.

Additionally, a _blacklist_ is created from lowercase variants of all of the camelCase SVG attributes, and the test fails on any of those because they're most likely an error. In other words, `viewBox` is valid, but `viewbox` is not.

Fixes #50.