### PR TITLE
new rule: enforce `name` getter on custom elements

### DIFF
--- a/lib/configs/browser.js
+++ b/lib/configs/browser.js
@@ -8,7 +8,8 @@ module.exports = {
     'github/async-preventdefault': 'error',
     'github/get-attribute': 'error',
     'github/no-innerText': 'error',
-    'github/unescaped-html-literal': 'error'
+    'github/unescaped-html-literal': 'error',
+    'github/custom-elements-must-have-name': 'error'
   },
   extends: [require.resolve('./recommended')]
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ module.exports = {
     'async-currenttarget': require('./rules/async-currenttarget'),
     'async-preventdefault': require('./rules/async-preventdefault'),
     'authenticity-token': require('./rules/authenticity-token'),
+    'custom-elements-must-have-name': require('./rules/custom-elements-must-have-name'),
     'dependency-graph': require('./rules/dependency-graph'),
     'get-attribute': require('./rules/get-attribute'),
     'js-class-name': require('./rules/js-class-name'),

--- a/lib/rules/custom-elements-must-have-name.js
+++ b/lib/rules/custom-elements-must-have-name.js
@@ -1,0 +1,74 @@
+module.exports = function(context) {
+  const messageNoGetter = 'Custom elements need to implement `static get name()`'
+  const messageMultipleStatements = '`static get name()` should only return string'
+  const messageNotMatching = '`static get name()` should return the name of the class'
+
+  return {
+    ClassDeclaration(node) {
+      const hasSuperClass = node.superClass
+      const superClassIsElement = hasSuperClass && node.superClass.name.endsWith('Element')
+
+      if (!hasSuperClass || !superClassIsElement) return
+
+      let getter
+      for (const method of node.body.body) {
+        if (method.type !== 'MethodDefinition') continue
+        if (!method.static) continue
+        if (method.kind !== 'get') continue
+        if (method.key.name !== 'name') continue
+        getter = method
+        break
+      }
+
+      if (!getter) {
+        return context.report({
+          node,
+          message: messageNoGetter,
+          meta: {
+            fixable: 'code'
+          },
+          fix(fixer) {
+            if (node.body.body.length) {
+              return fixer.insertTextBefore(node.body.body[0], `static get name() { return '${node.id.name}'} `)
+            }
+            return fixer.replaceText(
+              node,
+              `class ${node.id.name} extends ${node.superClass.name} { static get name() { return '${node.id.name}' } }`
+            )
+          }
+        })
+      }
+
+      if (getter.value.body.body.length !== 1 || getter.value.body.body[0].type !== 'ReturnStatement') {
+        return context.report({
+          node: getter.value.body.body[0],
+          message: messageMultipleStatements,
+          meta: {
+            fixable: 'code'
+          },
+          fix(fixer) {
+            return getter.value.body.body.map((statement, i) => {
+              if (i === 0) return fixer.replaceText(getter.value.body.body[0], `return '${node.id.name}'`)
+              return fixer.remove(statement)
+            })
+          }
+        })
+      }
+
+      const returnStatement = getter.value.body.body[0]
+
+      if (returnStatement.argument.type !== 'Literal' || returnStatement.argument.value !== node.id.name) {
+        return context.report({
+          node: returnStatement,
+          message: messageNotMatching,
+          meta: {
+            fixable: 'code'
+          },
+          fix(fixer) {
+            return fixer.replaceText(returnStatement, `return '${node.id.name}'`)
+          }
+        })
+      }
+    }
+  }
+}

--- a/tests/custom-elements-must-have-name.js
+++ b/tests/custom-elements-must-have-name.js
@@ -1,0 +1,67 @@
+var rule = require('../lib/rules/custom-elements-must-have-name')
+var RuleTester = require('eslint').RuleTester
+
+var ruleTester = new RuleTester()
+
+ruleTester.run('custom-elements-must-have-name', rule, {
+  valid: [
+    {
+      code: 'class FooElement extends HTMLElement { static get name() { return "FooElement" } }',
+      parserOptions: {ecmaVersion: 2017}
+    },
+    {
+      code: 'class FooElement { }',
+      parserOptions: {ecmaVersion: 2017}
+    },
+    {
+      code: 'class FooBar { doThing() { return "thing" } }',
+      parserOptions: {ecmaVersion: 2017}
+    }
+  ],
+  invalid: [
+    {
+      code: 'class FooElement extends HTMLElement {}',
+      parserOptions: {ecmaVersion: 2017},
+      errors: [
+        {
+          message: 'Custom elements need to implement `static get name()`',
+          type: 'ClassDeclaration'
+        }
+      ],
+      output: "class FooElement extends HTMLElement { static get name() { return 'FooElement' } }"
+    },
+    {
+      code: 'class FooElement extends HTMLElement { static get name() { return "Foo" } }',
+      parserOptions: {ecmaVersion: 2017},
+      errors: [
+        {
+          message: '`static get name()` should return the name of the class',
+          type: 'ReturnStatement'
+        }
+      ],
+      output: "class FooElement extends HTMLElement { static get name() { return 'FooElement' } }"
+    },
+    {
+      code: 'class FooElement extends HTMLElement { static get name() { const name = "Foo"; return name; } }',
+      parserOptions: {ecmaVersion: 2017},
+      errors: [
+        {
+          message: '`static get name()` should only return string',
+          type: 'VariableDeclaration'
+        }
+      ],
+      output: "class FooElement extends HTMLElement { static get name() { return 'FooElement'  } }"
+    },
+    {
+      code: 'class FooElement extends HTMLElement { static get thing() { return "Foo"; } }',
+      parserOptions: {ecmaVersion: 2017},
+      errors: [
+        {
+          message: 'Custom elements need to implement `static get name()`',
+          type: 'ClassDeclaration'
+        }
+      ],
+      output: `class FooElement extends HTMLElement { static get name() { return 'FooElement'} static get thing() { return "Foo"; } }`
+    }
+  ]
+})


### PR DESCRIPTION
Most minifiers will rename variables, classes and functions to a single letter, or more if the alphabet has been exhausted. This means that any call to `Function.name` will result in unwanted results.

This patch adds a rule that applies to custom elements. The rule enforces the existence of a `static get name()` method that returns the name of the class as a string. Ensuring that any call to `.name` on the custom element will result in the correct name.