### PR TITLE
Add eslint-comments

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: ['github', 'prettier'],
+  plugins: ['github', 'prettier', 'eslint-comments'],
   env: {
     commonjs: true
   },
@@ -7,6 +7,18 @@ module.exports = {
     camelcase: ['error', {properties: 'always'}],
     'constructor-super': 'error',
     eqeqeq: ['error', 'smart'],
+    'eslint-comments/no-unused-enable': 'error',
+    'eslint-comments/no-unused-disable': 'error',
+    'eslint-comments/disable-enable-pair': 'off',
+    'eslint-comments/no-aggregating-enable': 'off',
+    'eslint-comments/no-duplicate-disable': 'error',
+    'eslint-comments/no-unlimited-disable': 'error',
+    'eslint-comments/no-use': [
+      'error',
+      {
+        allow: ['eslint', 'eslint-disable-next-line', 'eslint-env', 'globals']
+      }
+    ],
     'func-style': ['error', 'declaration', {allowArrowFunctions: true}],
     'github/no-implicit-buggy-globals': 'error',
     'no-case-declarations': 'error',

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "babel-eslint": ">=8.2.0",
     "eslint-config-prettier": ">=2.9.0",
+    "eslint-plugin-eslint-comments": ">=3.0.1",
     "eslint-plugin-flowtype": ">=2.49.3",
     "eslint-plugin-graphql": ">=2.1.0",
     "eslint-plugin-import": ">=2.11.0",


### PR DESCRIPTION
@josh and I talked about wanting to disallow `/* eslint-disable */`  to prevent unintentional additions of rule-breaking code in a file.

I was gonna `grep` all our js files directly, but then found [`eslint-comments`](https://github.com/mysticatea/eslint-plugin-eslint-comments) which does exactly what we want and more— 

- We currently run `eslint` with `--report-unused-disable-directives`. With `no-unused-disable` these can be caught in the editor before CI linter.
- With `no-unlimited-disable` a rule is required for every `eslint-disable` comment.

Check out dotcom branch `muan/eslint-lint` for changes required. 