### PR TITLE
Check the object keys for strings and not the object itself

### DIFF
--- a/bin/eslint-github-init.js
+++ b/bin/eslint-github-init.js
@@ -17,8 +17,8 @@ if (fs.existsSync(packagePath)) {
   const packageJSON = JSON.parse(fs.readFileSync(packagePath, 'utf8'))
   defaults.project = packageJSON.private ? 'app' : 'lib'
 
-  const dependencies = Object.keys(packageJSON.dependencies)
-  const devDependencies = Object.keys(packageJSON.devDependencies)
+  const dependencies = Object.keys(packageJSON.dependencies || {})
+  const devDependencies = Object.keys(packageJSON.devDependencies || {})
 
   defaults.flow = dependencies.includes('flow-bin') || devDependencies.includes('flow-bin')
   defaults.react = dependencies.includes('react') || devDependencies.includes('react')

--- a/bin/eslint-github-init.js
+++ b/bin/eslint-github-init.js
@@ -16,9 +16,13 @@ const packagePath = path.resolve(process.cwd(), 'package.json')
 if (fs.existsSync(packagePath)) {
   const packageJSON = JSON.parse(fs.readFileSync(packagePath, 'utf8'))
   defaults.project = packageJSON.private ? 'app' : 'lib'
-  defaults.flow = packageJSON.dependencies.includes('flow-bin') || packageJSON.devDependencies.includes('flow-bin')
-  defaults.react = packageJSON.dependencies.includes('react') || packageJSON.devDependencies.includes('react')
-  defaults.relay = packageJSON.dependencies.includes('relay') || packageJSON.devDependencies.includes('relay')
+
+  const dependencies = Object.keys(packageJSON.dependencies)
+  const devDependencies = Object.keys(packageJSON.devDependencies)
+
+  defaults.flow = dependencies.includes('flow-bin') || devDependencies.includes('flow-bin')
+  defaults.react = dependencies.includes('react') || devDependencies.includes('react')
+  defaults.relay = dependencies.includes('relay') || devDependencies.includes('relay')
 }
 
 const questions = [


### PR DESCRIPTION
I messed up in #57 and tried to call `includes(..)` on the object instead of getting the object keys first and then calling `.includes(..)` on it 😅 