### PR TITLE
Add eslint-disable-next-line instead of eslint-disable comments

### DIFF
--- a/bin/eslint-ignore-errors.js
+++ b/bin/eslint-ignore-errors.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Disables eslint rules in a JavaScript file with global comments. This is
+// Disables eslint rules in a JavaScript file with next-line comments. This is
 // useful when introducing a new rule that causes many failures. The comments
 // can be fixed and removed at while updating the file later.
 //
@@ -13,14 +13,41 @@ const execFile = require('child_process').execFile
 execFile('eslint', ['--format', 'json', process.argv[2]], (error, stdout) => {
   JSON.parse(stdout).forEach(result => {
     const filename = result.filePath
+    const jsLines = fs.readFileSync(filename, 'utf8').split('\n')
+    const offensesByLine = {}
+    let addedLines = 0
 
-    const ruleIds = new Set()
-    result.messages.forEach(message => ruleIds.add(message.ruleId))
+    // Produces {47: ['github/no-d-none', 'github/no-blur'], 83: ['github/no-blur']}
+    result.messages.forEach(message => {
+      if (offensesByLine[message.line]) {
+        offensesByLine[message.line].push(message.ruleId)
+      } else {
+        offensesByLine[message.line] = [message.ruleId]
+      }
+    })
 
-    const js = fs.readFileSync(filename, 'utf8')
-    const comments = Array.from(ruleIds).map(ruleId => `/* eslint-disable ${ruleId} */`)
-    if (comments.length) {
-      fs.writeFileSync(filename, `${comments.join('\n')}\n${js}`, 'utf8')
-    }
+    Object.keys(offensesByLine).forEach(line => {
+      const lineIndex = line - 1 + addedLines
+      const previousLine = jsLines[lineIndex - 1]
+      const ruleIds = offensesByLine[line].join(', ')
+      if (isDisableComment(previousLine)) {
+        jsLines[lineIndex - 1] = jsLines[lineIndex - 1].replace(/\s?\*\/$/, `, ${ruleIds} */`)
+      } else {
+        jsLines.splice(lineIndex, 0, leftPad(jsLines[lineIndex]) + `/* eslint-disable-next-line ${ruleIds} */`)
+      }
+      addedLines += 1
+    })
+
+    fs.writeFileSync(filename, jsLines.join('\n'), 'utf8')
   })
 })
+
+function isDisableComment(line) {
+  return line.match(/\/\* eslint-disable-next-line .+\*\//)
+}
+
+function leftPad(line) {
+  const spaceMatch = line.match(/^\s+/g)
+  const spaces = spaceMatch ? spaceMatch[0].length : 0
+  return new Array(spaces).fill(' ').join('')
+}

--- a/bin/eslint-ignore-errors.js
+++ b/bin/eslint-ignore-errors.js
@@ -38,7 +38,9 @@ execFile('eslint', ['--format', 'json', process.argv[2]], (error, stdout) => {
       addedLines += 1
     })
 
-    fs.writeFileSync(filename, jsLines.join('\n'), 'utf8')
+    if (result.messages.length !== 0) {
+      fs.writeFileSync(filename, jsLines.join('\n'), 'utf8')
+    }
   })
 })
 

--- a/bin/eslint-ignore-errors.js
+++ b/bin/eslint-ignore-errors.js
@@ -51,5 +51,5 @@ function isDisableComment(line) {
 function leftPad(line) {
   const spaceMatch = line.match(/^\s+/g)
   const spaces = spaceMatch ? spaceMatch[0].length : 0
-  return new Array(spaces).fill(' ').join('')
+  return ' '.repeat(spaces)
 }

--- a/bin/eslint-ignore-errors.js
+++ b/bin/eslint-ignore-errors.js
@@ -31,9 +31,10 @@ execFile('eslint', ['--format', 'json', process.argv[2]], (error, stdout) => {
       const previousLine = jsLines[lineIndex - 1]
       const ruleIds = offensesByLine[line].join(', ')
       if (isDisableComment(previousLine)) {
-        jsLines[lineIndex - 1] = jsLines[lineIndex - 1].replace(/\s?\*\/$/, `, ${ruleIds} */`)
+        jsLines[lineIndex - 1] = previousLine.replace(/\s?\*\/$/, `, ${ruleIds} */`)
       } else {
-        jsLines.splice(lineIndex, 0, leftPad(jsLines[lineIndex]) + `/* eslint-disable-next-line ${ruleIds} */`)
+        const leftPad = ' '.repeat(jsLines[lineIndex].match(/^\s*/g)[0].length)
+        jsLines.splice(lineIndex, 0, `${leftPad}/* eslint-disable-next-line ${ruleIds} */`)
       }
       addedLines += 1
     })
@@ -46,10 +47,4 @@ execFile('eslint', ['--format', 'json', process.argv[2]], (error, stdout) => {
 
 function isDisableComment(line) {
   return line.match(/\/\* eslint-disable-next-line .+\*\//)
-}
-
-function leftPad(line) {
-  const spaceMatch = line.match(/^\s+/g)
-  const spaces = spaceMatch ? spaceMatch[0].length : 0
-  return ' '.repeat(spaces)
 }


### PR DESCRIPTION
With #54, global disable comments are no longer allowed. This changes so `eslint-ignore-errors filepath.js` would add `eslint-disable-next-line` comments instead.

This also handles the case where a `eslint-disable-next-line` comment already exist. It will append the rule to the existing comment instead of adding another comment.

This is what https://github.com/github/github/pull/105648 used! 🙌 

cc @josh