### PR TITLE
Disallow primative constructor types

### DIFF
--- a/lib/configs/flow.js
+++ b/lib/configs/flow.js
@@ -6,6 +6,7 @@ module.exports = {
     'flowtype/require-valid-file-annotation': ['error', 'always', {annotationStyle: 'block'}],
     'flowtype/use-flow-type': 'error',
     'flowtype/no-flow-fix-me-comments': 'error',
+    'flowtype/no-primitive-constructor-types': 'error',
     'flowtype/no-weak-types': 'error',
     'github/no-flow-weak': 'error',
     'github/no-noflow': 'error'


### PR DESCRIPTION
This PR enables the `flowtype/no-primitive-constructor-types` rule which will disallow primitive constructors to be used as types. This essentially means that you don't do:

```javascript
type x = Number
```

but rather 

```javascript
type x = number
```

This is beneficial since `Number` and `number` are different types and being consistent on what types you use in your codebase means you won't run as much into weird type mismatches. From the `flow` documentation:

```
- A `number` is a literal value like `42` or `3.14` or the result of an expression like `parseFloat(x)`.
- A `Number` is a wrapper object created by the global `new Number(x)` constructor.
``` 

Ref: https://github.com/github/github/pull/99483/#discussion_r248974123

### 📚 Further reading

- [`flowtype/no-primitive-constructor-types` documentation](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-no-primitive-constructor-types)
- [The `flowtype` documentation on primitives](https://flow.org/en/docs/types/primitives/)