### PR TITLE
Detect the react version

### DIFF
--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -5,6 +5,9 @@ module.exports = {
       jsx: true
     }
   },
+  settings: {
+    version: 'detect'
+  },
   env: {
     jest: true,
     node: true

--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -6,7 +6,9 @@ module.exports = {
     }
   },
   settings: {
-    version: 'detect'
+    react: {
+      version: 'detect'
+    }
   },
   env: {
     jest: true,


### PR DESCRIPTION
Since we aren't using the [reccomended config](https://github.com/yannickcr/eslint-plugin-react#configuration) that comes with we need to set `eslint-plugin-react` to detect the react version from our `package.json`.

It's not super important but we do get a warning telling us to set the version when linting.