### PR TITLE
feat: add no-edge-destructure-bug rule

### DIFF
--- a/docs/rules/no-edge-destructure-bug.md
+++ b/docs/rules/no-edge-destructure-bug.md
@@ -1,0 +1,31 @@
+# Edge 15-17 Destructuring Bug
+
+There's an interesting bug within Edge 15-17 where if you use _object destructuring_ with _default assignments_ _only_ on the _second_ argument of an _arrow function_, then you'll get a SyntaxError. In other words:
+
+   - `({a}) => a` ✔️ passes
+   - `({a}, {b}) => a + b` ✔️ passes
+   - `({a = 1}, {b}) => a + b` ✔️ passes
+   - `({a = 1}, {b = 1}) => a + b`  ✔️ passes
+   - `(a, {b}) => a + b`  ✔️ passes
+   - `(a, {b = 1}) => a + b` ❌ SyntaxError
+   - `([a], {b=1}) => a + b` ❌ SyntaxError
+   - `([a=1], {b=1}) => a + b` ❌ SyntaxError
+   - `(a, {b=1} = {}) => a + b` ✔️ passes
+   - `function (a, {b = 1}) { return a + b }`  ✔️ passes
+    
+A faily exhaustive set of rules to trigger this error:
+
+ - It has to be an arrow function, anonymous `function`s work fine.
+ - If the first argument is object destructuring with defaults, it fixes the error.
+ - Subsequent arguments must use defaults, if you're just destructuring without defaults it works fine.
+ 
+## What is the Fix?
+
+The most straight forward fix is to stop using destructuring with defaults on your second parameter. There are several options to avoid this, going from most straightforward to least straightforward:
+
+ - Use an anonymous function expression, instead of an arrow function. Change `(a, { b = 1 }) => {}` to `function(a, { b = 1}) {}`
+ - Ensure to assign the destructuring expression to an object: change `(a, { b = 1 }) => {}` to `(a, { b = 1 } = {}) => {}`
+ - Destructure in the function body: change `(a, { b = 1 }) => {}` to `(a, o) => { let {b = 1} = o }`
+ - Default the arguments in the function body: change `(a, { b = 1 }) => {}` to `(a, { b }) => { b = b || 1 }`
+ - If you can, destructure the first argument and use defaults. I'm not going to add an example because this fix will hugely depend on your code - only do this if you're confident enough to do so.
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ module.exports = {
     'no-blur': require('./rules/no-blur'),
     'no-d-none': require('./rules/no-d-none'),
     'no-dataset': require('./rules/no-dataset'),
+    'no-edge-destructure-bug': require('./rules/no-edge-destructure-bug'),
     'no-flow-weak': require('./rules/no-flow-weak'),
     'no-implicit-buggy-globals': require('./rules/no-implicit-buggy-globals'),
     'no-innerText': require('./rules/no-innerText'),

--- a/lib/rules/no-edge-destructure-bug.js
+++ b/lib/rules/no-edge-destructure-bug.js
@@ -1,0 +1,29 @@
+const objectPatternHasDefaults = node =>
+  node.type === 'ObjectPattern' && node.properties.some(prop => prop.value.type === 'AssignmentPattern')
+
+module.exports = function(context) {
+  return {
+    ArrowFunctionExpression(node) {
+      // Unary functions don't trip on this bug
+      if (node.params.length < 2) return
+
+      // This bug only occurs when some arguments use Object destructuring
+      if (!node.params.some(param => param.type === 'ObjectPattern')) return
+
+      const objectPatternArgs = node.params.filter(node => node.type === 'ObjectPattern')
+
+      // This bug is only occurs when an argument uses Object Destructuring with Default assignment
+      if (!objectPatternArgs.some(objectPatternHasDefaults)) return
+
+      // This bug gets fixed if the first argument uses Object destructuring with default assignments!
+      if (node.params[0].type === 'ObjectPattern' && objectPatternHasDefaults(node.params[0])) return
+
+      context.report(
+        node,
+        'There is an Edge 15-17 bug which causes second argument destructuring to fail. See https://git.io/fhd7N for more'
+      )
+    }
+  }
+}
+
+module.exports.schema = []

--- a/tests/no-edge-destructure-bug.js
+++ b/tests/no-edge-destructure-bug.js
@@ -1,0 +1,77 @@
+var rule = require('../lib/rules/no-edge-destructure-bug')
+var RuleTester = require('eslint').RuleTester
+
+var ruleTester = new RuleTester({parserOptions: {ecmaVersion: 2018}})
+
+ruleTester.run('no-edge-destructure-bug', rule, {
+  valid: [
+    {code: '({a}) => a'},
+    {code: '({a}, {b}) => a + b'},
+    {code: '({a = 1}, {b}) => a + b'},
+    {code: '({a = 1}, {b = 1}) => a + b'},
+    {code: '({a = 1}, {b = 1}, {c = 1}) => a + b'},
+    {code: '({a = 1}, {b}, {c = 1}) => a + b'},
+    {code: '([a], {b}) => a + b'},
+    {code: '([a], {b}) => a + b'},
+    {code: '([a=1], {b}) => a + b'},
+    {code: '(a, {b = 1} = {b: 1}) => a + b'},
+    {code: '(a, {b}) => a + b'},
+    {code: 'var f = function (a, {b = 1}) { return a + b }'}
+  ],
+  invalid: [
+    {
+      code: '(a, {b = 1}) => a + b',
+      errors: [
+        {
+          message:
+            'There is an Edge 15-17 bug which causes second argument destructuring to fail. See https://git.io/fhd7N for more'
+        }
+      ]
+    },
+    {
+      code: '([a], {b=1}) => a + b',
+      errors: [
+        {
+          message:
+            'There is an Edge 15-17 bug which causes second argument destructuring to fail. See https://git.io/fhd7N for more'
+        }
+      ]
+    },
+    {
+      code: '([a=1], {b=1}) => a + b',
+      errors: [
+        {
+          message:
+            'There is an Edge 15-17 bug which causes second argument destructuring to fail. See https://git.io/fhd7N for more'
+        }
+      ]
+    },
+    {
+      code: '({a}, {b=1}) => a + b',
+      errors: [
+        {
+          message:
+            'There is an Edge 15-17 bug which causes second argument destructuring to fail. See https://git.io/fhd7N for more'
+        }
+      ]
+    },
+    {
+      code: '({a}, {b}, {c=1}) => a + b + c',
+      errors: [
+        {
+          message:
+            'There is an Edge 15-17 bug which causes second argument destructuring to fail. See https://git.io/fhd7N for more'
+        }
+      ]
+    },
+    {
+      code: '({a}, {b=1}, {c=1}) => a + b + c',
+      errors: [
+        {
+          message:
+            'There is an Edge 15-17 bug which causes second argument destructuring to fail. See https://git.io/fhd7N for more'
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
When shipping code without Babel's `@babel/transform-es2015-destructuring` transform there is an interesting bug in Edge 15-17 which will cause a SyntaxError if you use _object destructuring_ with _default assignments_ _only_ on the _second_ argument of an _arrow function_, then you'll get a SyntaxError. In other words:

   - `({a}) => a` ✔️ passes
   - `({a}, {b}) => a + b` ✔️ passes
   - `({a = 1}, {b}) => a + b` ✔️ passes
   - `({a = 1}, {b = 1}) => a + b`  ✔️ passes
   - `(a, {b}) => a + b`  ✔️ passes
   - `(a, {b = 1}) => a + b` ❌ SyntaxError
   - `([a], {b=1}) => a + b` ❌ SyntaxError
   - `([a=1], {b=1}) => a + b` ❌ SyntaxError
   - `(a, {b=1} = {}) => a + b` ✔️ passes
   - `function (a, {b = 1}) { return a + b }`  ✔️ passes

This bug is documented on Babel (https://github.com/babel/babel/issues/8349), and Kangax (https://github.com/kangax/compat-table/issues/1076). This lint rule gives us an opportunity to ship untransformed code, but also guard against issues where this SyntaxError could occur in Edge 15-17. 