### PR TITLE
feat: add no-shadow to recommended rules

### DIFF
--- a/bin/flow-coverage.js
+++ b/bin/flow-coverage.js
@@ -6,7 +6,7 @@
 const childProcess = require('child_process')
 const flow = require('flow-bin')
 const fs = require('fs')
-const path = require('path')
+const {join} = require('path')
 
 const execFile = (file, args) =>
   new Promise((resolve, reject) => {
@@ -86,7 +86,7 @@ async function grepFlowFiles() {
 ;(async function() {
   let threshold = 0
 
-  const packageJsonPath = path.join(process.cwd(), 'package.json')
+  const packageJsonPath = join(process.cwd(), 'package.json')
   if (fs.existsSync(packageJsonPath)) {
     const packageJson = require(packageJsonPath)
     threshold = (packageJson.flow && packageJson.flow.coverageThreshold) || 0

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -55,6 +55,7 @@ module.exports = {
     'no-regex-spaces': 'error',
     'no-return-assign': 'error',
     'no-self-assign': 'error',
+    'no-shadow': 'error',
     'no-sparse-arrays': 'error',
     'no-this-before-super': 'error',
     'no-throw-literal': 'error',

--- a/lib/rules/dependency-graph.js
+++ b/lib/rules/dependency-graph.js
@@ -19,11 +19,11 @@ module.exports = {
 
     checkEntriesWhitelist(filename)
 
-    function recordImport(filename, symbol) {
-      let symbols = imports.get(filename)
+    function recordImport(importPath, symbol) {
+      let symbols = imports.get(importPath)
       if (!symbols) {
         symbols = new Set()
-        imports.set(filename, symbols)
+        imports.set(importPath, symbols)
       }
 
       if (symbol) {


### PR DESCRIPTION
We've seen a few issues where shadowing variables has caused bugs. This lint rule prevents shadowing so we can prevent these kinds of bugs.