### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-rule-documentation": ">=1.0.0",
     "inquirer": "^6.0.0",
     "prettier": ">=1.12.0",
-    "read-pkg-up": "^4.0.0",
+    "read-pkg-up": "^6.0.0",
     "svg-element-attributes": "^1.2.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^1.3.0",
     "@typescript-eslint/parser": "^1.3.0",
     "babel-eslint": ">=8.2.0",
-    "eslint-config-prettier": "^4.0.0",
+    "eslint-config-prettier": "^5.1.0",
     "eslint-plugin-eslint-comments": ">=3.0.1",
     "eslint-plugin-flowtype": ">=2.49.3",
     "eslint-plugin-graphql": ">=3.0.1",
@@ -63,7 +63,7 @@
     "prettier.config.js"
   ],
   "devDependencies": {
-    "eslint": "^4.8.0",
+    "eslint": "^5.16.0",
     "flow-bin": "^0.74.0",
     "graphql": "^14.0.2",
     "mocha": "^5.1.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^1.3.0",
     "@typescript-eslint/parser": "^1.3.0",
     "babel-eslint": ">=8.2.0",
-    "eslint-config-prettier": "^5.1.0",
+    "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-eslint-comments": ">=3.0.1",
     "eslint-plugin-flowtype": ">=2.49.3",
     "eslint-plugin-graphql": ">=3.0.1",
@@ -63,9 +63,9 @@
     "prettier.config.js"
   ],
   "devDependencies": {
-    "eslint": "^5.16.0",
-    "flow-bin": "^0.74.0",
+    "eslint": "^6.0.1",
+    "flow-bin": "^0.102.0",
     "graphql": "^14.0.2",
-    "mocha": "^5.1.0"
+    "mocha": "^6.1.4"
   }
 }

--- a/tests/no-implicit-buggy-globals.js
+++ b/tests/no-implicit-buggy-globals.js
@@ -18,15 +18,15 @@ ruleTester.run('no-implicit-buggy-globals', rule, {
     },
     {
       code: 'var foo = 1;',
-      parserOptions: {sourceType: 'module'}
+      parserOptions: {sourceType: 'module', ecmaVersion: 2015}
     },
     {
       code: 'let foo = 1;',
-      parserOptions: {sourceType: 'module'}
+      parserOptions: {sourceType: 'module', ecmaVersion: 2015}
     },
     {
       code: 'const foo = 1;',
-      parserOptions: {sourceType: 'module'}
+      parserOptions: {sourceType: 'module', ecmaVersion: 2015}
     }
   ],
   invalid: [


### PR DESCRIPTION
[ESLint 6 was just released](https://github.com/eslint/eslint/releases/tag/v6.0.0) and we are still on ESLint 4.

This PR updates ESLint and other dependencies to their latest versions. 