### PR TITLE
Embrace JSDoc

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: ['github', 'prettier', 'eslint-comments'],
+  plugins: ['github', 'prettier', 'eslint-comments', 'jsdoc'],
   env: {
     commonjs: true
   },
@@ -21,6 +21,12 @@ module.exports = {
     ],
     'func-style': ['error', 'declaration', {allowArrowFunctions: true}],
     'github/no-implicit-buggy-globals': 'error',
+    'jsdoc/check-alignment': 'error',
+    'jsdoc/check-indentation': 'error',
+    'jsdoc/check-param-names': 'error',
+    'jsdoc/check-syntax': 'error',
+    'jsdoc/check-tag-names': 'error',
+    'jsdoc/newline-after-description': 'error',
     'no-case-declarations': 'error',
     'no-class-assign': 'error',
     'no-compare-neg-zero': 'error',

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-graphql": ">=3.0.1",
     "eslint-plugin-import": ">=2.11.0",
     "eslint-plugin-jest": ">=21.15.0",
+    "eslint-plugin-jsdoc": ">=15.5.2",
     "eslint-plugin-jsx-a11y": ">=6.0.0",
     "eslint-plugin-prettier": ">=2.6.0",
     "eslint-plugin-react": ">=7.7.0",


### PR DESCRIPTION
GitHub has loosely been using [TomDoc](http://tomdoc.org/) for documenting JS.

I propose we start to migrate away from that style to [JSDoc](https://devdocs.io/jsdoc/). JSDoc is a bit more strict of a syntax than TomDoc but it's big advantage is that it's the annotation standard [used by TypeScript](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html).

I think JSDoc could be a great choice for GitHub's open source libraries. JSDoc has been around for quite some type and is relatively stable. Since it's a comment annotation, it's compatible with vanilla JS without the need for a babel transform. It's appealing to write native ES modules for Custom Elements that we can `<script type=module>`  load into browsers without any transforms for testing and demos.

On the cons, JSDoc is a bit more strict and finicky than TomDoc's free-flowing markdown-ish style. I think these lint rules can come in handy to ensure consistent style and help auto-format people's indentation. It also validates and finds syntax errors. The rules here do not enforce JSDoc. They just intend to valid JSDoc comments if they do exist.

What does the @github/web-systems team (and friend @myobie) think?