### PR TITLE
Add Flow to TypeScript transitioning rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ module.exports = {
     'async-preventdefault': require('./rules/async-preventdefault'),
     'authenticity-token': require('./rules/authenticity-token'),
     'dependency-graph': require('./rules/dependency-graph'),
+    'flow-to-typescript': require('./rules/flow-to-typescript'),
     'get-attribute': require('./rules/get-attribute'),
     'js-class-name': require('./rules/js-class-name'),
     'no-blur': require('./rules/no-blur'),

--- a/lib/rules/flow-to-typescript.js
+++ b/lib/rules/flow-to-typescript.js
@@ -1,0 +1,18 @@
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
+
+  create(context) {
+    return {
+      Program(node) {
+        const comments = context.getSourceCode().getAllComments()
+        const enabledTypeChecker = comments.some(comment => comment.value.trim().match(/@ts-check|@flow/))
+        if (!enabledTypeChecker) {
+          context.report(node, 'File must be type checked by TypeScript or Flow.')
+        }
+      }
+    }
+  }
+}

--- a/tests/flow-to-typescript.js
+++ b/tests/flow-to-typescript.js
@@ -1,0 +1,19 @@
+var rule = require('../lib/rules/flow-to-typescript')
+var RuleTester = require('eslint').RuleTester
+
+var ruleTester = new RuleTester()
+
+ruleTester.run('flow-to-typescript', rule, {
+  valid: [{code: '/* @flow */'}, {code: '/* @flow weak */'}, {code: '/* @flow strict */'}, {code: '// @ts-check'}],
+  invalid: [
+    {
+      code: '/* @closure-compiler */',
+      errors: [
+        {
+          message: 'File must be type checked by TypeScript or Flow.',
+          type: 'Program'
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
Adds rule to enforce either `@flow` or `@ts-check` on a file. Projects transitioning to TypeScript should enable this rule and disable the [flow ruleset](https://github.com/github/eslint-plugin-github/blob/master/lib/configs/flow.js).