### PR TITLE
fix: add support for Eslint 6 in stylish-fixes

### DIFF
--- a/lib/formatters/stylish-fixes.js
+++ b/lib/formatters/stylish-fixes.js
@@ -7,7 +7,7 @@ const path = require('path')
 let SourceCodeFixer = null
 try {
   SourceCodeFixer = require('eslint/lib/linter/source-code-fixer')
-} catch(e) {
+} catch (e) {
   SourceCodeFixer = require('eslint/lib/util/source-code-fixer')
 }
 const getRuleURI = require('eslint-rule-documentation')

--- a/lib/formatters/stylish-fixes.js
+++ b/lib/formatters/stylish-fixes.js
@@ -4,7 +4,12 @@ const childProcess = require('child_process')
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
-const SourceCodeFixer = require('eslint/lib/util/source-code-fixer')
+let SourceCodeFixer = null
+try {
+  SourceCodeFixer = require('eslint/lib/linter/source-code-fixer')
+} catch(e) {
+  SourceCodeFixer = require('eslint/lib/util/source-code-fixer')
+}
 const getRuleURI = require('eslint-rule-documentation')
 
 module.exports = function(results) {


### PR DESCRIPTION
eslint@6 changes the structure of internal files, moving `lib/util/source-code-fixer` to `lib/linter/source-code-fixer`.

This does a `try`/`catch` to load from both paths, meaning it will work with eslint@6 as well as eslint@5