### PR TITLE
Fix TS ext

### DIFF
--- a/bin/github-lint.js
+++ b/bin/github-lint.js
@@ -27,7 +27,7 @@ function execFile(command, args) {
   const isTypeScriptProject = fs.existsSync('tsconfig.json')
 
   if (isTypeScriptProject) {
-    eslintOptions = eslintOptions.concat(['--ext', '.ts,.tsx'])
+    eslintOptions = eslintOptions.concat(['--ext', '.js,.ts,.tsx'])
   }
 
   commands.push(['eslint', eslintOptions])


### PR DESCRIPTION
If the project is a TS project, it doesn't necessarily mean there are no .js files in the codebase, so we should preserve the .js extension.