### PR TITLE
feat: follow symlinks in dependency graph

### DIFF
--- a/lib/dependency-graph.js
+++ b/lib/dependency-graph.js
@@ -41,10 +41,15 @@ function gatherImported() {
 
   for (const {imports} of dependencyGraph.values()) {
     for (const [importedFilename, importedIdentifiers] of imports) {
-      filenames.add(importedFilename)
+      // require.resolve will expand any symlinks to their fully qualified
+      // directories. We can use this (with the absolute path given in
+      // importedFilename to quickly expand symlinks, which allows us to have
+      // symlinks (aka workspaces) in node_modules, and not fail the lint.
+      const fullyQualifiedImportedFilename = require.resolve(importedFilename)
+      filenames.add(fullyQualifiedImportedFilename)
 
       for (const importedIdentifier of importedIdentifiers) {
-        identifiers.add(`${importedFilename}#${importedIdentifier}`)
+        identifiers.add(`${fullyQualifiedImportedFilename}#${importedIdentifier}`)
       }
     }
   }


### PR DESCRIPTION
## What?

This adds a call to `require.resolve` within `dependency-graph`, as `require.resolve` will canonicalize any symlinks within the path, to get the fully qualified path.

## Why?

This allows us to use symlinks (such as npm link or yarn workspaces) and have the dependency graph resolve to the fully qualified files on disk. Without this change the dependency graph will only read the path, where the linter will lookup and resolve the existing files, and so there becomes a mismatch. Resolving symlinks resolves the mismatch.

We could optionally avoid using `require.resolve` and use `fs.readlink` - but `fs.readlink` will _not_ canonicalize paths, in other words if `node_modules/foo` was a symlink then `fs.readlink('node_modules/foo')` would resolve, but `fs.readlink('node_modules/foo/bar.js')` would throw (other methods like `fs.readFile('node_modules/foo/bar.js')` will resolve as they _do_ canonicalise symlinks).