### PR TITLE
Change default setting from a string to a object

### DIFF
--- a/lib/configs/typescript.js
+++ b/lib/configs/typescript.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   plugins: ['@typescript-eslint', 'github'],
   rules: {
-    '@typescript-eslint/array-type': ['error', 'array-simple'],
+    '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off'


### PR DESCRIPTION
After #77 we make consumers of this lib install the latest versions of all the dependencies so when packages make breaking changes it will break in those applications.

One of those breaking changes come from `@typescript-eslint/eslint-plugin` where the array type option was changed from a simple string to an options object.

This PR changes the array type option from a `'array-simple'` string to a `{default: 'array-simple'}` option object.

The breaking change was made in https://github.com/typescript-eslint/typescript-eslint/pull/654 and you can read the docs for the rule [here](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md)