### PR TITLE
Fix dependency graph after read pkg up breaking change

### DIFF
--- a/lib/dependency-graph.js
+++ b/lib/dependency-graph.js
@@ -16,21 +16,21 @@ exports.checkEntriesWhitelist = filename => {
   }
 }
 
-const packageJSON = readPkgUp.sync()
+const packageFile = readPkgUp.sync()
 
 function recordPackageEntry(entry) {
-  exports.entries.add(path.resolve(packageJSON.path, '..', entry))
+  exports.entries.add(path.resolve(packageFile.path, '..', entry))
 }
 
-if (packageJSON) {
-  for (const key in packageJSON.package) {
+if (packageFile) {
+  for (const key in packageFile.package) {
     if (key === 'main') {
-      recordPackageEntry(packageJSON.package.main)
+      recordPackageEntry(packageFile.package.main)
     } else if (key === 'entries') {
-      packageJSON.package.entries.forEach(recordPackageEntry)
+      packageFile.package.entries.forEach(recordPackageEntry)
     } else if (/-bundles$/.test(key)) {
       // github-asset-pipeline internal manifest format
-      Object.keys(packageJSON.package[key]).forEach(recordPackageEntry)
+      Object.keys(packageFile.package[key]).forEach(recordPackageEntry)
     }
   }
 }

--- a/lib/dependency-graph.js
+++ b/lib/dependency-graph.js
@@ -23,14 +23,14 @@ function recordPackageEntry(entry) {
 }
 
 if (packageFile) {
-  for (const key in packageFile.package) {
+  for (const key in packageFile.packageJson) {
     if (key === 'main') {
-      recordPackageEntry(packageFile.package.main)
+      recordPackageEntry(packageFile.packageJson.main)
     } else if (key === 'entries') {
-      packageFile.package.entries.forEach(recordPackageEntry)
+      packageFile.packageJson.entries.forEach(recordPackageEntry)
     } else if (/-bundles$/.test(key)) {
       // github-asset-pipeline internal manifest format
-      Object.keys(packageFile.package[key]).forEach(recordPackageEntry)
+      Object.keys(packageFile.packageJson[key]).forEach(recordPackageEntry)
     }
   }
 }


### PR DESCRIPTION
The key was set to `package` in [6.0.0](https://github.com/sindresorhus/read-pkg-up/releases/tag/v6.0.0) but then changed to `packageJson` in [`7.0.0`](https://github.com/sindresorhus/read-pkg-up/releases/tag/v7.0.0) since `package` is a keyword.

Since we install whatever the latest version of packages after #77 we update to the breaking change in applications consuming this library.