### PR TITLE
fix: Consistent max buffer value across Node versions.

### DIFF
--- a/bin/github-lint.js
+++ b/bin/github-lint.js
@@ -9,7 +9,7 @@ const path = require('path')
 
 function execFile(command, args) {
   return new Promise(resolve => {
-    childProcess.execFile(command, args, (error, stdout, stderr) => {
+    childProcess.execFile(command, args, {maxBuffer: 1024 ** 2}, (error, stdout, stderr) => {
       resolve({code: error ? error.code : 0, stdout, stderr})
     })
   })


### PR DESCRIPTION
Before Node v12, `maxBuffer` defaulted to 200kb. Node v12+ defaults to 1024kb.

Setting the `maxBuffer` value allows for a more consistent cross-version Node experience.