### PR TITLE
feat: Run ESLint with colors in supported environments

### DIFF
--- a/bin/github-lint.js
+++ b/bin/github-lint.js
@@ -22,7 +22,7 @@ function execFile(command, args) {
 
   const packageJson = fs.existsSync('package.json') ? require(path.join(process.cwd(), 'package.json')) : {}
 
-  let eslintOptions = ['--report-unused-disable-directives', '.']
+  let eslintOptions = ['--color', '--report-unused-disable-directives', '.']
 
   const isTypeScriptProject = fs.existsSync('tsconfig.json')
 

--- a/bin/github-lint.js
+++ b/bin/github-lint.js
@@ -25,7 +25,7 @@ function execFile(command, args) {
 
   const packageJson = fs.existsSync('package.json') ? require(path.join(process.cwd(), 'package.json')) : {}
 
-  let eslintOptions = ['--color', '--report-unused-disable-directives', '.']
+  let eslintOptions = ['--report-unused-disable-directives', '.']
 
   if (hasBasicColorSupport) {
     eslintOptions = eslintOptions.concat(['--color'])

--- a/bin/github-lint.js
+++ b/bin/github-lint.js
@@ -6,6 +6,9 @@
 const childProcess = require('child_process')
 const fs = require('fs')
 const path = require('path')
+const supportsColors = require('supports-color')
+
+const hasBasicColorSupport = supportsColors.stdout.hasBasic && supportsColors.stderr.hasBasic
 
 function execFile(command, args) {
   return new Promise(resolve => {
@@ -23,6 +26,10 @@ function execFile(command, args) {
   const packageJson = fs.existsSync('package.json') ? require(path.join(process.cwd(), 'package.json')) : {}
 
   let eslintOptions = ['--color', '--report-unused-disable-directives', '.']
+
+  if (hasBasicColorSupport) {
+    eslintOptions = eslintOptions.concat(['--color'])
+  }
 
   const isTypeScriptProject = fs.existsSync('tsconfig.json')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -371,6 +371,16 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "chardet": {
@@ -2269,11 +2279,18 @@
       "dev": true
     },
     "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        }
       }
     },
     "svg-element-attributes": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "inquirer": ">=6.0.0",
     "prettier": ">=1.12.0",
     "read-pkg-up": ">=6.0.0",
+    "supports-color": "^7.1.0",
     "svg-element-attributes": ">=1.2.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
My guess is ESLint is disabling color formatting because it's unable to detect a TTY when invoked through `execFile()`.

Comparision

![lint-with-no-color](https://user-images.githubusercontent.com/10104630/70323630-28a26300-17e2-11ea-97c8-22c84712c10e.png)

![lint-with-color](https://user-images.githubusercontent.com/10104630/70323636-29d39000-17e2-11ea-900a-46aa2531301d.png)
