### PR TITLE
Resolve `.ts` files as well as `.js` files

### DIFF
--- a/lib/configs/es6.js
+++ b/lib/configs/es6.js
@@ -40,5 +40,12 @@ module.exports = {
     'prefer-spread': 'error',
     'prefer-template': 'error'
   },
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.ts']
+      }
+    }
+  },
   extends: [require.resolve('./recommended')]
 }


### PR DESCRIPTION
When you have a `.ts` file such as `button.ts` and try to import it without it's file extension, the current config will error with the message:

```
app.js
1:1 import/no-unresolved  (https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md)
	Unable to resolve path to module './button'.


✖ 1 problem (1 error, 0 warnings)
```

It's because by default the `import` plugin will only look for `.js` files.

This PR passes an array of file extensions for the `import` plugin to consider as settings in the `es6` config.

Ref: https://github.com/benmosher/eslint-plugin-import/blob/master/README.md#importextensions