### PR TITLE
Use `typescript-eslint/parser` as parser in typescript config

### DIFF
--- a/lib/configs/typescript.js
+++ b/lib/configs/typescript.js
@@ -1,8 +1,6 @@
 module.exports = {
   extends: ['plugin:@typescript-eslint/recommended', 'prettier', 'prettier/@typescript-eslint'],
-  parserOptions: {
-    project: './tsconfig.json'
-  },
+  parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'github'],
   rules: {
     '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],


### PR DESCRIPTION
Use `typescript-eslint/parser` as the ESLint parser when a app extends the `typescript` config.

This part has been split out from #90 to be more reviewable.

This is a breaking change and will be published as major version 4 once everything from #90 has been merged into `master`.