### PR TITLE
Turn eslint `camelcase` rule off in typescript config

### DIFF
--- a/lib/configs/typescript.js
+++ b/lib/configs/typescript.js
@@ -3,6 +3,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'github'],
   rules: {
+    camelcase: 'off',
     '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',


### PR DESCRIPTION
`@typescript-eslint` already has a `camelcase` rule so we'll use that one instead of the default `eslint` one.

https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/camelcase.md