### PR TITLE
Turn off `no-non-null-assertion` rule

### DIFF
--- a/lib/configs/typescript.js
+++ b/lib/configs/typescript.js
@@ -6,6 +6,7 @@ module.exports = {
     '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
-    '@typescript-eslint/explicit-function-return-type': 'off'
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off'
   }
 }


### PR DESCRIPTION
We currently like this assertion method and have it all over our codebase. We'll probably move away from this as we gain more type coverage where possible but for now we should just turn it off.

https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-non-null-assertion.md