### PR TITLE
Use prettier from npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,12 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@github/prettier-config": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@github/prettier-config/-/prettier-config-0.0.4.tgz",
+      "integrity": "sha512-ZOJ+U771Mw68qp2GPbcqPt2Xg0LEl0YwiIFHXwVLAFm2TgDnsgcCHhXO8PIxOWPqSFO4S7xIMD9CBobfaWGASA==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prettier": ">=1.12.0",
     "svg-element-attributes": ">=1.3.1"
   },
+  "prettier": "@github/prettier-config",
   "peerDependencies": {
     "eslint": ">=4.19.0"
   },
@@ -44,6 +45,7 @@
     "prettier.config.js"
   ],
   "devDependencies": {
+    "@github/prettier-config": "0.0.4",
     "eslint": ">=6.8.0",
     "mocha": ">=7.1.1"
   }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  printWidth: 120,
-  semi: false,
-  singleQuote: true,
-  bracketSpacing: false
-}


### PR DESCRIPTION
`@github/prettier-config` is our centralized prettier config, so we can use that instead of maintaining our own `prettier.config.js` file.