### PR TITLE
Change typescript rules

### DIFF
--- a/lib/configs/typescript.js
+++ b/lib/configs/typescript.js
@@ -4,6 +4,7 @@ module.exports = {
   plugins: ['@typescript-eslint', 'github'],
   rules: {
     camelcase: 'off',
+    'no-unused-vars': 'off',
     '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',

--- a/lib/configs/typescript.js
+++ b/lib/configs/typescript.js
@@ -5,6 +5,7 @@ module.exports = {
   rules: {
     camelcase: 'off',
     'no-unused-vars': 'off',
+    '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',


### PR DESCRIPTION
eae37ab

`@typescript-eslint` already includes a [`no-unused-vars`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md) rule so we use that one instead.

be71c95

I think we want to just allow people to name their interfaces whatever they want.
