### PR TITLE
Turn off `@typescript-eslint/no-empty-function'` rule.

### DIFF
--- a/lib/configs/typescript.js
+++ b/lib/configs/typescript.js
@@ -4,12 +4,12 @@ module.exports = {
   plugins: ['@typescript-eslint', 'github'],
   rules: {
     camelcase: 'off',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],
-    '@typescript-eslint/no-use-before-define': 'off',
-    '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/no-non-null-assertion': 'off'
+    '@typescript-eslint/explicit-member-accessibility': 'off',
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-use-before-define': 'off',
+    'no-unused-vars': 'off'
   }
 }

--- a/lib/configs/typescript.js
+++ b/lib/configs/typescript.js
@@ -8,6 +8,7 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
     'no-unused-vars': 'off'


### PR DESCRIPTION
We seem to overwrite this rule in `github/github` all the time with no clear path of removing the disable comments so I figure this rule isn't doing anything and can safely be turned off.