### PR TITLE
Don't extends configs in the browser and internal configs

### DIFF
--- a/lib/configs/browser.js
+++ b/lib/configs/browser.js
@@ -11,6 +11,5 @@ module.exports = {
     'github/no-dataset': 'error',
     'github/no-innerText': 'error',
     'github/unescaped-html-literal': 'error'
-  },
-  extends: [require.resolve('./recommended')]
+  }
 }

--- a/lib/configs/internal.js
+++ b/lib/configs/internal.js
@@ -4,6 +4,5 @@ module.exports = {
     'github/authenticity-token': 'error',
     'github/js-class-name': 'error',
     'github/no-d-none': 'error'
-  },
-  extends: [require.resolve('./recommended'), require.resolve('./browser')]
+  }
 }


### PR DESCRIPTION
It's not apparent to consumers of this plugin that when they extend the `browser` or `internal` configs they are extending the `recommended` config as well.

By not extending them in those configs we make the consumers denote each config they want to extend and give them the freedom to compose those configs together however they want.

This is a breaking change for consumers that have been relying on getting the recommended rules through the other configs.