### PR TITLE
Remove `prettier.config.js` from files entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
   },
   "files": [
     "bin/*",
-    "lib/*",
-    "prettier.config.js"
+    "lib/*"
   ],
   "devDependencies": {
     "@github/prettier-config": "0.0.4",


### PR DESCRIPTION
I have noticed that since version `v4.0.0-1` the following `prettier.config.js`
file has been removed, meaning that it could be removed from the `files` entry.

see: https://github.com/github/eslint-plugin-github/compare/v4.0.0-0...v4.0.0-1

**Additional context:**

When running `npm pack --dry-run` we can see that `prettier.config.js` isn't
part of the generated tarball.

```sh
$ npm pack --dry-run
npm notice 
npm notice 📦  eslint-plugin-github@4.1.0
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE                               
npm notice 310B  lib/rules/array-foreach.js            
npm notice 568B  lib/rules/async-currenttarget.js      
npm notice 584B  lib/rules/async-preventdefault.js     
npm notice 568B  lib/rules/authenticity-token.js       
npm notice 489B  lib/configs/browser.js                
npm notice 1.8kB bin/eslint-ignore-errors.js           
npm notice 1.6kB lib/rules/get-attribute.js            
npm notice 993B  lib/index.js                          
npm notice 170B  lib/configs/internal.js               
npm notice 1.5kB lib/rules/js-class-name.js            
npm notice 305B  lib/rules/no-blur.js                  
npm notice 606B  lib/rules/no-d-none.js                
npm notice 317B  lib/rules/no-dataset.js               
npm notice 742B  lib/rules/no-implicit-buggy-globals.js
npm notice 532B  lib/rules/no-innerText.js             
npm notice 435B  lib/rules/no-then.js                  
npm notice 1.7kB lib/rules/no-useless-passive.js       
npm notice 589B  lib/rules/prefer-observers.js         
npm notice 3.7kB lib/configs/recommended.js            
npm notice 808B  lib/rules/require-passive-events.js   
npm notice 2.2kB lib/formatters/stylish-fixes.js       
npm notice 632B  lib/configs/typescript.js             
npm notice 565B  lib/rules/unescaped-html-literal.js   
npm notice 1.6kB package.json                          
npm notice 634B  README.md                             
npm notice === Tarball Details === 
npm notice name:          eslint-plugin-github                    
npm notice version:       4.1.0                                   
npm notice filename:      eslint-plugin-github-4.1.0.tgz          
npm notice package size:  7.8 kB                                  
npm notice unpacked size: 24.8 kB                                 
npm notice shasum:        829858e74030f9864acde0b3b4c23c2cf418de05
npm notice integrity:     sha512-gN8DYZ1mWO3jO[...]2Hoqm7mN/rgYQ==
npm notice total files:   26                                      
npm notice 
eslint-plugin-github-4.1.0.tgz
```

Hope you'll find this useful.
Thank you!