### PR TITLE
fix: add missing rules to index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,10 @@ module.exports = {
     'no-implicit-buggy-globals': require('./rules/no-implicit-buggy-globals'),
     'no-innerText': require('./rules/no-innerText'),
     'no-then': require('./rules/no-then'),
-    'unescaped-html-literal': require('./rules/unescaped-html-literal')
+    'unescaped-html-literal': require('./rules/unescaped-html-literal'),
+    'no-useless-passive': require('./rules/no-useless-passive'),
+    'prefer-observers': require('./rules/prefer-observers'),
+    'require-passive-events': require('./rules/require-passive-events')
   },
   configs: {
     internal: require('./configs/internal'),


### PR DESCRIPTION
This adds the missing rules added in `4.1`. :disappointed: 