### PR TITLE
ci: remove travis ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - "10"
-  - "12"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # eslint-plugin-github
 
+[![Node CI](https://github.com/github/eslint-plugin-github/actions/workflows/nodejs.yml/badge.svg)](https://github.com/github/eslint-plugin-github/actions/workflows/nodejs.yml)
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
Appears this project now uses GitHub actions instead of Travis as a CI. 

Is the Travis CI config still required? 

It still runs on pull requests. Should this be changed to GitHub actions?

Also added GitHub Action badge to README.md
