### PR TITLE
Add info into the `meta` property of rules

### DIFF
--- a/lib/rules/array-foreach.js
+++ b/lib/rules/array-foreach.js
@@ -3,7 +3,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce `for..of` loops over `Array.forEach`',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/array-foreach.md'
+      url: require('../url')(module)
     },
     schema: []
   },

--- a/lib/rules/array-foreach.js
+++ b/lib/rules/array-foreach.js
@@ -1,6 +1,10 @@
 module.exports = {
   meta: {
-    docs: {},
+    type: 'suggestion',
+    docs: {
+      description: 'enforce `for..of` loops over `Array.forEach`',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/array-foreach.md'
+    },
     schema: []
   },
 

--- a/lib/rules/async-currenttarget.js
+++ b/lib/rules/async-currenttarget.js
@@ -3,7 +3,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow `event.currentTarget` calls inside of async functions',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/async-currenttarget.md'
+      url: require('../url')(module)
     },
     schema: []
   },

--- a/lib/rules/async-currenttarget.js
+++ b/lib/rules/async-currenttarget.js
@@ -1,6 +1,10 @@
 module.exports = {
   meta: {
-    docs: {},
+    type: 'problem',
+    docs: {
+      description: 'disallow `event.currentTarget` calls inside of async functions',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/async-currenttarget.md'
+    },
     schema: []
   },
 

--- a/lib/rules/async-preventdefault.js
+++ b/lib/rules/async-preventdefault.js
@@ -1,6 +1,10 @@
 module.exports = {
   meta: {
-    docs: {},
+    type: 'problem',
+    docs: {
+      description: 'disallow `event.preventDefault` calls inside of async functions',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/async-preventDefault.md'
+    },
     schema: []
   },
 

--- a/lib/rules/async-preventdefault.js
+++ b/lib/rules/async-preventdefault.js
@@ -3,7 +3,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow `event.preventDefault` calls inside of async functions',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/async-preventDefault.md'
+      url: require('../url')(module)
     },
     schema: []
   },

--- a/lib/rules/authenticity-token.js
+++ b/lib/rules/authenticity-token.js
@@ -1,6 +1,10 @@
 module.exports = {
   meta: {
-    docs: {},
+    type: 'problem',
+    docs: {
+      description: 'disallow usage of CSRF tokens in JavaScript',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/authenticity-token.md'
+    },
     schema: []
   },
 

--- a/lib/rules/authenticity-token.js
+++ b/lib/rules/authenticity-token.js
@@ -3,7 +3,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow usage of CSRF tokens in JavaScript',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/authenticity-token.md'
+      url: require('../url')(module)
     },
     schema: []
   },

--- a/lib/rules/get-attribute.js
+++ b/lib/rules/get-attribute.js
@@ -23,7 +23,7 @@ module.exports = function(context) {
       type: 'problem',
       docs: {
         description: 'disallow wrong usage of attribute names',
-        url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/get-attribute.md'
+        url: require('../url')(module)
       },
       fixable: 'code',
       schema: []

--- a/lib/rules/get-attribute.js
+++ b/lib/rules/get-attribute.js
@@ -19,6 +19,15 @@ function isValidAttribute(name) {
 
 module.exports = function(context) {
   return {
+    meta: {
+      type: 'problem',
+      docs: {
+        description: 'disallow wrong usage of attribute names',
+        url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/get-attribute.md'
+      },
+      fixable: 'code',
+      schema: []
+    },
     CallExpression(node) {
       if (!node.callee.property) return
 

--- a/lib/rules/js-class-name.js
+++ b/lib/rules/js-class-name.js
@@ -3,7 +3,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce a naming convention for js- prefixed classes',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/js-class-name.md'
+      url: require('../url')(module)
     },
     schema: []
   },

--- a/lib/rules/js-class-name.js
+++ b/lib/rules/js-class-name.js
@@ -1,6 +1,10 @@
 module.exports = {
   meta: {
-    docs: {},
+    type: 'suggestion',
+    docs: {
+      description: 'enforce a naming convention for js- prefixed classes',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/js-class-name.md'
+    },
     schema: []
   },
 

--- a/lib/rules/no-blur.js
+++ b/lib/rules/no-blur.js
@@ -4,7 +4,7 @@ module.exports = function(context) {
       type: 'problem',
       docs: {
         description: 'disallow usage of `Element.prototype.blur()`',
-        url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-blur.md'
+        url: require('../url')(module)
       },
       schema: []
     },

--- a/lib/rules/no-blur.js
+++ b/lib/rules/no-blur.js
@@ -1,5 +1,13 @@
 module.exports = function(context) {
   return {
+    meta: {
+      type: 'problem',
+      docs: {
+        description: 'disallow usage of `Element.prototype.blur()`',
+        url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-blur.md'
+      },
+      schema: []
+    },
     CallExpression(node) {
       if (node.callee.property && node.callee.property.name === 'blur') {
         context.report(node, 'Do not use element.blur(), instead restore the focus of a previous element.')
@@ -7,5 +15,3 @@ module.exports = function(context) {
     }
   }
 }
-
-module.exports.schema = []

--- a/lib/rules/no-d-none.js
+++ b/lib/rules/no-d-none.js
@@ -3,7 +3,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow usage the `d-none` CSS class',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-d-none.md'
+      url: require('../url')(module)
     },
     schema: []
   },

--- a/lib/rules/no-d-none.js
+++ b/lib/rules/no-d-none.js
@@ -1,4 +1,12 @@
 module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow usage the `d-none` CSS class',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-d-none.md'
+    },
+    schema: []
+  },
   create(context) {
     return {
       CallExpression(node) {

--- a/lib/rules/no-dataset.js
+++ b/lib/rules/no-dataset.js
@@ -3,7 +3,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'enforce usage of `Element.prototype.getAttribute` instead of `Element.prototype.datalist`',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-dataset.md'
+      url: require('../url')(module)
     },
     schema: []
   },

--- a/lib/rules/no-dataset.js
+++ b/lib/rules/no-dataset.js
@@ -1,6 +1,10 @@
 module.exports = {
   meta: {
-    docs: {},
+    type: 'problem',
+    docs: {
+      description: 'enforce usage of `Element.prototype.getAttribute` instead of `Element.prototype.datalist`',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-dataset.md'
+    },
     schema: []
   },
 

--- a/lib/rules/no-implicit-buggy-globals.js
+++ b/lib/rules/no-implicit-buggy-globals.js
@@ -3,7 +3,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow implicit global variables',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-implicit-buggy-globals.md'
+      url: require('../url')(module)
     },
     schema: []
   },

--- a/lib/rules/no-implicit-buggy-globals.js
+++ b/lib/rules/no-implicit-buggy-globals.js
@@ -1,6 +1,10 @@
 module.exports = {
   meta: {
-    docs: {},
+    type: 'problem',
+    docs: {
+      description: 'disallow implicit global variables',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-implicit-buggy-globals.md'
+    },
     schema: []
   },
 

--- a/lib/rules/no-innerText.js
+++ b/lib/rules/no-innerText.js
@@ -3,7 +3,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow `Element.prototype.innerText` in favor of `Element.prototype.textContent`',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-innerText.md'
+      url: require('../url')(module)
     },
     fixable: 'code',
     schema: []

--- a/lib/rules/no-innerText.js
+++ b/lib/rules/no-innerText.js
@@ -1,7 +1,12 @@
 module.exports = {
   meta: {
-    docs: {},
-    fixable: 'code'
+    type: 'problem',
+    docs: {
+      description: 'disallow `Element.prototype.innerText` in favor of `Element.prototype.textContent`',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-innerText.md'
+    },
+    fixable: 'code',
+    schema: []
   },
 
   create(context) {

--- a/lib/rules/no-then.js
+++ b/lib/rules/no-then.js
@@ -1,6 +1,11 @@
 module.exports = {
   meta: {
-    docs: {}
+    type: 'suggestion',
+    docs: {
+      description: 'enforce using `async/await` syntax over Promises',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-then.md'
+    },
+    schema: []
   },
 
   create(context) {

--- a/lib/rules/no-then.js
+++ b/lib/rules/no-then.js
@@ -3,7 +3,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce using `async/await` syntax over Promises',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-then.md'
+      url: require('../url')(module)
     },
     schema: []
   },

--- a/lib/rules/no-useless-passive.js
+++ b/lib/rules/no-useless-passive.js
@@ -7,7 +7,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow marking a event handler as passive when it has no effect',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-useless-passive.md'
+      url: require('../url')(module)
     },
     fixable: 'code',
     schema: []

--- a/lib/rules/no-useless-passive.js
+++ b/lib/rules/no-useless-passive.js
@@ -4,8 +4,13 @@ const propIsPassiveTrue = prop => prop.key && prop.key.name === 'passive' && pro
 
 module.exports = {
   meta: {
-    docs: {},
-    fixable: 'code'
+    type: 'suggestion',
+    docs: {
+      description: 'disallow marking a event handler as passive when it has no effect',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/no-useless-passive.md'
+    },
+    fixable: 'code',
+    schema: []
   },
 
   create(context) {

--- a/lib/rules/prefer-observers.js
+++ b/lib/rules/prefer-observers.js
@@ -4,8 +4,12 @@ const observerMap = {
 }
 module.exports = {
   meta: {
-    docs: {},
-    fixable: 'code'
+    type: 'suggestion',
+    docs: {
+      description: 'disallow poorly performing event listeners',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/prefer-observers.md'
+    },
+    schema: []
   },
 
   create(context) {

--- a/lib/rules/prefer-observers.js
+++ b/lib/rules/prefer-observers.js
@@ -7,7 +7,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow poorly performing event listeners',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/prefer-observers.md'
+      url: require('../url')(module)
     },
     schema: []
   },

--- a/lib/rules/require-passive-events.js
+++ b/lib/rules/require-passive-events.js
@@ -4,7 +4,12 @@ const propIsPassiveTrue = prop => prop.key && prop.key.name === 'passive' && pro
 
 module.exports = {
   meta: {
-    docs: {}
+    type: 'suggestion',
+    docs: {
+      description: 'enforce marking high frequency event handlers as passive',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/require-passive-events.md'
+    },
+    schema: []
   },
 
   create(context) {

--- a/lib/rules/require-passive-events.js
+++ b/lib/rules/require-passive-events.js
@@ -7,7 +7,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce marking high frequency event handlers as passive',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/require-passive-events.md'
+      url: require('../url')(module)
     },
     schema: []
   },

--- a/lib/rules/unescaped-html-literal.js
+++ b/lib/rules/unescaped-html-literal.js
@@ -1,24 +1,35 @@
-module.exports = function(context) {
-  const htmlOpenTag = /^<[a-zA-Z]/
-  const message = 'Unescaped HTML literal. Use html`` tag template literal for secure escaping.'
-
-  return {
-    Literal(node) {
-      if (!htmlOpenTag.test(node.value)) return
-
-      context.report({
-        node,
-        message
-      })
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow unesaped HTML literals',
+      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/unescaped-html-literal.md'
     },
-    TemplateLiteral(node) {
-      if (!htmlOpenTag.test(node.quasis[0].value.raw)) return
+    schema: []
+  },
 
-      if (!node.parent.tag || node.parent.tag.name !== 'html') {
+  create(context) {
+    const htmlOpenTag = /^<[a-zA-Z]/
+    const message = 'Unescaped HTML literal. Use html`` tag template literal for secure escaping.'
+
+    return {
+      Literal(node) {
+        if (!htmlOpenTag.test(node.value)) return
+
         context.report({
           node,
           message
         })
+      },
+      TemplateLiteral(node) {
+        if (!htmlOpenTag.test(node.quasis[0].value.raw)) return
+
+        if (!node.parent.tag || node.parent.tag.name !== 'html') {
+          context.report({
+            node,
+            message
+          })
+        }
       }
     }
   }

--- a/lib/rules/unescaped-html-literal.js
+++ b/lib/rules/unescaped-html-literal.js
@@ -3,7 +3,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow unesaped HTML literals',
-      url: 'https://github.com/github/eslint-plugin-github/blob/main/docs/rules/unescaped-html-literal.md'
+      url: require('../url')(module)
     },
     schema: []
   },

--- a/lib/url.js
+++ b/lib/url.js
@@ -1,0 +1,9 @@
+const {homepage, version} = require('../package.json')
+const path = require('path')
+module.exports = ({id}) => {
+  const url = new URL(homepage)
+  const rule = path.basename(id, '.js')
+  url.hash = ''
+  url.pathname += `/blob/v${version}/docs/rules/${rule}.md`
+  return url.toString()
+}


### PR DESCRIPTION
It's good to have this info filled out. I was also hoping we could add https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin to lint these rules and their tests; this change is in preparation for that.

## References
https://eslint.org/docs/developer-guide/working-with-rules#rule-basics