### PR TITLE
fixes typescript named/imports for github/typescript

### DIFF
--- a/lib/configs/typescript.js
+++ b/lib/configs/typescript.js
@@ -5,6 +5,8 @@ module.exports = {
   rules: {
     camelcase: 'off',
     'no-unused-vars': 'off',
+    'import/named': 'off',
+    '@typescript-eslint/import/named': ['error'],
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],
     '@typescript-eslint/no-use-before-define': 'off',


### PR DESCRIPTION
The `import/named` rule from ESLint Core will report on lines that don't violate the rule when run on TypeScript files. We should probably do something similar to our `no-shadow fix`

## References

https://github.com/github/eslint-plugin-github/pull/127