### PR TITLE
invalid value fix for typescript no-shadow rule

### DIFF
--- a/lib/configs/typescript.js
+++ b/lib/configs/typescript.js
@@ -6,7 +6,7 @@ module.exports = {
     camelcase: 'off',
     'no-unused-vars': 'off',
     'no-shadow': 'off',
-    '@typescript-eslint/no-shadow': 'on',
+    '@typescript-eslint/no-shadow': ['error'],
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],
     '@typescript-eslint/no-use-before-define': 'off',


### PR DESCRIPTION
`on` is an invalid value for `plugin:github/typescript` `@typescript-eslint/no-shadow` rule

**Error:**
```
.eslintrc.js » plugin:github/typescript: Configuration for rule "@typescript-eslint/no-shadow" is invalid: Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '"on"').
```

relates to https://github.com/github/eslint-plugin-github/commit/7285de26b887db3d9bc7104d68718c8578302908 https://github.com/github/eslint-plugin-github/pull/127