### PR TITLE
Add no-only-tests JS linter rule to detect test.only and suite.only

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,13 +8,19 @@ module.exports = {
     node: true
   },
   extends: [require.resolve('./lib/configs/recommended'), 'plugin:eslint-plugin/all'],
-  plugins: ['eslint-plugin'],
+  plugins: ['eslint-plugin', 'no-only-tests'],
   rules: {
     'import/no-commonjs': 'off',
     'filenames/match-regex': 'off',
     'i18n-text/no-en': 'off',
     'eslint-plugin/prefer-placeholders': 'off',
     'eslint-plugin/test-case-shorthand-strings': 'off',
-    'eslint-plugin/require-meta-docs-url': 'off'
+    'eslint-plugin/require-meta-docs-url': 'off',
+    'no-only-tests/no-only-tests': [
+      'error',
+      {
+        'block': ['describe', 'it', 'context', 'test', 'tape', 'fixture', 'serial', 'suite']
+      }
+    ]
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,19 +8,13 @@ module.exports = {
     node: true
   },
   extends: [require.resolve('./lib/configs/recommended'), 'plugin:eslint-plugin/all'],
-  plugins: ['eslint-plugin', 'no-only-tests'],
+  plugins: ['eslint-plugin'],
   rules: {
     'import/no-commonjs': 'off',
     'filenames/match-regex': 'off',
     'i18n-text/no-en': 'off',
     'eslint-plugin/prefer-placeholders': 'off',
     'eslint-plugin/test-case-shorthand-strings': 'off',
-    'eslint-plugin/require-meta-docs-url': 'off',
-    'no-only-tests/no-only-tests': [
-      'error',
-      {
-        block: ['describe', 'it', 'context', 'test', 'tape', 'fixture', 'serial', 'suite']
-      }
-    ]
+    'eslint-plugin/require-meta-docs-url': 'off'
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
     'no-only-tests/no-only-tests': [
       'error',
       {
-        'block': ['describe', 'it', 'context', 'test', 'tape', 'fixture', 'serial', 'suite']
+        block: ['describe', 'it', 'context', 'test', 'tape', 'fixture', 'serial', 'suite']
       }
     ]
   }

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -8,7 +8,7 @@ module.exports = {
   env: {
     es6: true
   },
-  plugins: ['github', 'prettier', 'eslint-comments', 'import', 'filenames', 'i18n-text'],
+  plugins: ['github', 'prettier', 'eslint-comments', 'import', 'filenames', 'i18n-text', 'no-only-tests'],
   rules: {
     'constructor-super': 'error',
     'eslint-comments/disable-enable-pair': 'off',
@@ -85,6 +85,12 @@ module.exports = {
     'no-new-symbol': 'error',
     'no-obj-calls': 'error',
     'no-octal': 'error',
+    'no-only-tests/no-only-tests': [
+      'error',
+      {
+        block: ['describe', 'it', 'context', 'test', 'tape', 'fixture', 'serial', 'suite']
+      }
+    ],
     'no-redeclare': 'error',
     'no-regex-spaces': 'error',
     'no-return-assign': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@github/prettier-config": "0.0.4",
         "eslint": "7.23.0",
         "eslint-plugin-eslint-plugin": "^2.3.0",
+        "eslint-plugin-no-only-tests": "^2.6.0",
         "eslint-visitor-keys": "^2.0.0",
         "globals": "^13.7.0",
         "mocha": "^8.3.2"
@@ -1049,6 +1050,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "3.3.1",
@@ -3974,6 +3984,12 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
+    },
+    "eslint-plugin-no-only-tests": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+      "dev": true
     },
     "eslint-plugin-prettier": {
       "version": "3.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-i18n-text": "^1.0.1",
         "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-no-only-tests": "^2.6.0",
         "eslint-plugin-prettier": "^3.3.1",
         "eslint-rule-documentation": ">=1.0.0",
         "prettier": "^2.2.1",
@@ -27,7 +28,6 @@
         "@github/prettier-config": "0.0.4",
         "eslint": "7.23.0",
         "eslint-plugin-eslint-plugin": "^2.3.0",
-        "eslint-plugin-no-only-tests": "^2.6.0",
         "eslint-visitor-keys": "^2.0.0",
         "globals": "^13.7.0",
         "mocha": "^8.3.2"
@@ -1055,7 +1055,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
       "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
-      "dev": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -3988,8 +3987,7 @@
     "eslint-plugin-no-only-tests": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
-      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
-      "dev": true
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q=="
     },
     "eslint-plugin-prettier": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@github/prettier-config": "0.0.4",
     "eslint": "7.23.0",
     "eslint-plugin-eslint-plugin": "^2.3.0",
+    "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-visitor-keys": "^2.0.0",
     "globals": "^13.7.0",
     "mocha": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-i18n-text": "^1.0.1",
     "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-rule-documentation": ">=1.0.0",
     "prettier": "^2.2.1",
@@ -49,7 +50,6 @@
     "@github/prettier-config": "0.0.4",
     "eslint": "7.23.0",
     "eslint-plugin-eslint-plugin": "^2.3.0",
-    "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-visitor-keys": "^2.0.0",
     "globals": "^13.7.0",
     "mocha": "^8.3.2"


### PR DESCRIPTION
This warns on leftovers like `suite.only` or `test.only` that would prevent all JS tests from running in CI.

Adding a dependency on this plugin: https://www.npmjs.com/package/eslint-plugin-no-only-tests
It meets the "LAWSUIT" external library criteria:
- **L**icensing: MIT licensed
- **A**ctively-developed: Latest commit 1 month ago, on June 17th
- **W**idely-used: 107,289 weekly downloads
- **S**upply chain safety: only dependency is "eslint"
- **U**nique functionality: Yes
- **I**nstall time impact + bundle size impact: Dev-time linter, no production impact.
- **T**ypeScript support: this doesn't apply to an eslint plugin.

By default, the library doesn't check `suite`, so I had to change the default value of `block` by adding it to the default values:
```
"block": ["describe", "it", "context", "test", "tape", "fixture", "serial", "suite"]
```

Tested with `npm link` successfully:
![image](https://user-images.githubusercontent.com/579705/128722574-a377b762-98d7-43f2-80c5-09c7cf118951.png)

> Note: I wasn't able to get `npm link` to work in Codespaces, I had to use my laptop. I got:
> npm was not found in PATH outside of this project
> I suspect it's due to `npm` not being installed in the dotcom Codespace, and even using the `bin/npm` in the $PATH didn't help.