### PR TITLE
apply suggested fix for no-invalid-this from typescript-eslint

### DIFF
--- a/lib/configs/typescript.js
+++ b/lib/configs/typescript.js
@@ -6,6 +6,8 @@ module.exports = {
     camelcase: 'off',
     'no-unused-vars': 'off',
     'no-shadow': 'off',
+    'no-invalid-this': "off",
+    '@typescript-eslint/no-invalid-this': ['error'],
     '@typescript-eslint/no-shadow': ['error'],
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],


### PR DESCRIPTION
closes https://github.com/github/eslint-plugin-github/issues/135

Applies solution by typescript-eslint https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-invalid-this.md

verified that by applying this overwrite the error provided in issue #135 is fixed as part of our project rules.