### PR TITLE
Fix the version of eslint-plugin-import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-i18n-text": "^1.0.1",
-        "eslint-plugin-import": "^2.24.2",
+        "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-no-only-tests": "^2.6.0",
         "eslint-plugin-prettier": "^3.3.1",
         "eslint-rule-documentation": ">=1.0.0",
@@ -2726,19 +2726,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -4834,12 +4821,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
-    },
-    "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
-      "peer": true
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-i18n-text": "^1.0.1",
-    "eslint-plugin-import": "^2.24.2",
+    "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-rule-documentation": ">=1.0.0",


### PR DESCRIPTION
I don't know why but `package.json` and `package-lock.json` look strange.

In the latest release v4.3.3, `eslint-plugin-import` is set to `"^2.24.2"`:
https://github.com/github/eslint-plugin-github/blob/v4.3.3/package.json#L34
But the version specified in `pakage-lock.json` is `"2.25.2"`:
https://github.com/github/eslint-plugin-github/blob/v4.3.3/package-lock.json#L954

Also, dependency to `typescrpit` disappeared by running `npm i`.
As far as I can see, there is no package depends on `typescript`.
So I think this is correect.

![image](https://user-images.githubusercontent.com/241542/140011807-412bc10f-2162-46ee-8482-f917689fc43c.png)

I'm using npm v7.24.2.

---

I hope that this repo will use dependabot or renovate to reduce manual modifications for dependencies.