### PR TITLE
chore: remove globals devDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "@github/prettier-config": "0.0.4",
         "eslint": "^8.0.1",
         "eslint-plugin-eslint-plugin": "^2.3.0",
-        "globals": "^13.7.0",
         "mocha": "^8.3.2"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@github/prettier-config": "0.0.4",
     "eslint": "^8.0.1",
     "eslint-plugin-eslint-plugin": "^2.3.0",
-    "globals": "^13.7.0",
     "mocha": "^8.3.2"
   }
 }


### PR DESCRIPTION
It's a dependency of ESLint, but not direclty referenced by the rules