### PR TITLE
Allow files to be named _.config.js

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -18,7 +18,7 @@ module.exports = {
     'eslint-comments/no-unused-disable': 'error',
     'eslint-comments/no-unused-enable': 'error',
     'eslint-comments/no-use': ['error', {allow: ['eslint', 'eslint-disable-next-line', 'eslint-env', 'globals']}],
-    'filenames/match-regex': ['error', '^[a-z0-9-]+(.d)?$'],
+    'filenames/match-regex': ['error', '^[a-z0-9-]+(.d|.config)?$'],
     'func-style': ['error', 'declaration', {allowArrowFunctions: true}],
     'github/array-foreach': 'error',
     'github/no-implicit-buggy-globals': 'error',


### PR DESCRIPTION
We allow many files to be named `*.config.js`, e.g. `postcss.config.js`, `rollup.config.js`, `karma.config.cjs`. 

This should be allowed in the lint rule, without having to override it.