### PR TITLE
Prefer import extensions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,8 @@ module.exports = {
     'no-useless-passive': require('./rules/no-useless-passive'),
     'prefer-observers': require('./rules/prefer-observers'),
     'require-passive-events': require('./rules/require-passive-events'),
-    'unescaped-html-literal': require('./rules/unescaped-html-literal')
+    'unescaped-html-literal': require('./rules/unescaped-html-literal'),
+    'prefer-import-extensions': require('./rules/prefer-import-extensions')
   },
   configs: {
     browser: require('./configs/browser'),

--- a/lib/rules/prefer-import-extensions.js
+++ b/lib/rules/prefer-import-extensions.js
@@ -1,0 +1,33 @@
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'disallow file imports with out a `.js` extension',
+      url: require('../url')(module)
+    },
+    schema: [],
+    fixable: 'code'
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        const source = node.source
+
+        if (!source.value.startsWith('.')) return
+        if (source.value.endsWith('.js')) return
+
+        context.report({
+          meta: {
+            fixable: 'code'
+          },
+          node: source,
+          message: 'The imported file is missing a file extension. Consider adding the `.js` extension.',
+          fix(fixer) {
+            const newValue = `'${source.value}.js'`
+            return fixer.replaceText(source, `${newValue}`)
+          }
+        })
+      }
+    }
+  }
+}

--- a/lib/rules/prefer-import-extensions.js
+++ b/lib/rules/prefer-import-extensions.js
@@ -5,23 +5,43 @@ module.exports = {
       description: 'disallow file imports with out a `.js` extension',
       url: require('../url')(module)
     },
-    schema: [],
+    schema: [
+      {
+        enum: ['always', 'never']
+      },
+      {
+        type: 'object',
+        properties: {
+          extensions: {
+            type: 'array'
+          }
+        },
+        additionalProperties: false
+      }
+    ],
     fixable: 'code'
   },
   create(context) {
+    const extensions = (context.options[1] && context.options[1].extensions) || ['js']
     return {
       ImportDeclaration(node) {
         const source = node.source
 
         if (!source.value.startsWith('.')) return
-        if (source.value.endsWith('.js')) return
+
+        const extension = source.value.split('.').pop()
+        if (extensions.includes(extension)) return
+
+        console.log(extensions)
 
         context.report({
           meta: {
             fixable: 'code'
           },
           node: source,
-          message: 'The imported file is missing a file extension. Consider adding the `.js` extension.',
+          message: `The imported file is missing a file extension. Consider adding a valid extension: "${extensions.join(
+            ', '
+          )}"`,
           fix(fixer) {
             const newValue = `'${source.value}.js'`
             return fixer.replaceText(source, `${newValue}`)

--- a/lib/rules/prefer-import-extensions.js
+++ b/lib/rules/prefer-import-extensions.js
@@ -32,8 +32,6 @@ module.exports = {
         const extension = source.value.split('.').pop()
         if (extensions.includes(extension)) return
 
-        console.log(extensions)
-
         context.report({
           meta: {
             fixable: 'code'

--- a/tests/prefer-import-extensions.js
+++ b/tests/prefer-import-extensions.js
@@ -1,0 +1,62 @@
+const rule = require('../lib/rules/prefer-import-extensions')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester()
+
+const parserOptions = {sourceType: 'module', ecmaVersion: 2021}
+
+ruleTester.run('prefer-import-extensions', rule, {
+  valid: [
+    {
+      code: "import './something.js'",
+      parserOptions
+    },
+    {
+      code: "import 'left-pad'",
+      parserOptions
+    },
+    {
+      code: "import '@github/eslint-plugin-github'",
+      parserOptions
+    },
+    {
+      code: "import {controller, target} from '@github/catalyst'",
+      parserOptions
+    }
+  ],
+  invalid: [
+    {
+      code: "import './something'",
+      output: "import './something.js'",
+      parserOptions,
+      errors: [
+        {
+          message: 'The imported file is missing a file extension. Consider adding the `.js` extension.',
+          type: 'Literal'
+        }
+      ]
+    },
+    {
+      code: "import './something/very/important'",
+      output: "import './something/very/important.js'",
+      parserOptions,
+      errors: [
+        {
+          message: 'The imported file is missing a file extension. Consider adding the `.js` extension.',
+          type: 'Literal'
+        }
+      ]
+    },
+    {
+      code: "import something from './somewhere'",
+      output: "import something from './somewhere.js'",
+      parserOptions,
+      errors: [
+        {
+          message: 'The imported file is missing a file extension. Consider adding the `.js` extension.',
+          type: 'Literal'
+        }
+      ]
+    }
+  ]
+})

--- a/tests/prefer-import-extensions.js
+++ b/tests/prefer-import-extensions.js
@@ -12,6 +12,11 @@ ruleTester.run('prefer-import-extensions', rule, {
       parserOptions
     },
     {
+      code: "import './something.css'",
+      options: ['always', {extensions: ['js', 'css']}],
+      parserOptions
+    },
+    {
       code: "import 'left-pad'",
       parserOptions
     },
@@ -31,7 +36,7 @@ ruleTester.run('prefer-import-extensions', rule, {
       parserOptions,
       errors: [
         {
-          message: 'The imported file is missing a file extension. Consider adding the `.js` extension.',
+          message: 'The imported file is missing a file extension. Consider adding a valid extension: "js"',
           type: 'Literal'
         }
       ]
@@ -42,7 +47,7 @@ ruleTester.run('prefer-import-extensions', rule, {
       parserOptions,
       errors: [
         {
-          message: 'The imported file is missing a file extension. Consider adding the `.js` extension.',
+          message: 'The imported file is missing a file extension. Consider adding a valid extension: "js"',
           type: 'Literal'
         }
       ]
@@ -53,7 +58,7 @@ ruleTester.run('prefer-import-extensions', rule, {
       parserOptions,
       errors: [
         {
-          message: 'The imported file is missing a file extension. Consider adding the `.js` extension.',
+          message: 'The imported file is missing a file extension. Consider adding a valid extension: "js"',
           type: 'Literal'
         }
       ]


### PR DESCRIPTION
A rule which enforces extensions on file imports. It's not perfect since it throws a `.js` extension on the import literal in the autofix but I'm unsure on the heuristics for our edge cases. I think in most cases we want imports to just have `.js` but this might change in the future, especially with [import assertions](https://github.com/tc39/proposal-import-assertions) on the horizon.