### PR TITLE
Remove `sort-imports` rule

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -118,7 +118,6 @@ module.exports = {
     'prefer-template': 'error',
     'prettier/prettier': 'error',
     'require-yield': 'error',
-    'sort-imports': 'error',
     'use-isnan': 'error',
     'valid-typeof': 'error',
     camelcase: ['error', {properties: 'always'}],


### PR DESCRIPTION
`sort-imports` seems to have a pretty inscrutable algorithm for _how_ it sorts. It's not based on the import specifier, and seems to be based on bindings. 

We see a lot of complaints about this rule:

 - The order is difficult to work out, making it high cognitive load to fix (or low cognitive load and multiple passes at running the lint rule until you do what it tells you)
 - It makes PR diffs messier as adding a binding can change the order required
 - It's not auto-fixable (which is exaggerated by the fact that the order is difficult to work out)
 - There seems to be no observable benefit to having imports sorted.

We added `sort-imports` in https://github.com/github/github/pull/51096 with a slew of other changes around import rules to catch bugs. However `sort-imports` didn't have good justification in isolation. Given the lack of justification originally, and given the amount of pain it causes today, I think it's a good idea to simply remove this rule.