### PR TITLE
Add an example for accessing the element index in a `for...of` loop

### DIFF
--- a/docs/rules/array-foreach.md
+++ b/docs/rules/array-foreach.md
@@ -95,7 +95,7 @@ for (const el of els) {
 Use [`entries()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/entries) to get access to the index:
 ```js
 for (const [i, el] of els.entries()) {
-  els.name = `Element ${i}`
+  el.name = `Element ${i}`
 }
 ```
 

--- a/docs/rules/array-foreach.md
+++ b/docs/rules/array-foreach.md
@@ -92,6 +92,13 @@ for (const el of els) {
 }
 ```
 
+Use [`entries()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/entries) to get access to the index:
+```js
+for (const [i, el] of els.entries()) {
+  els.name = `Element ${i}`
+}
+```
+
 ## Version
 
 4.3.2


### PR DESCRIPTION
Add an example using `Array.prototype.entries()` to access the element index in a `for...of` loop.

```js
for (const [i, el] of els.entries()) {
  el.name = `Element ${i}`
}
```

This is preferred over `for...in` because `for...in` does not guarantee that elements will be iterated over in the expected order (doesn't matter in the above example but it could in other cases).

And it's more readable than a standard `for` loop:
```js
for (let i = 0; i < els.length; i++) {
  els[i].name = `Element ${i}`
}
```


Resolves #216