### PR TITLE
[spike] Allow custom component to be mapped to element type

### DIFF
--- a/lib/rules/a11y-no-generic-link-text.js
+++ b/lib/rules/a11y-no-generic-link-text.js
@@ -1,5 +1,5 @@
 const {getProp, getPropValue} = require('jsx-ast-utils')
-const {getElementType} = require('../utils/get-element-type.js')
+const {getElementType} = require('../utils/get-element-type')
 
 const bannedLinkText = ['read more', 'here', 'click here', 'learn more', 'more', 'here']
 

--- a/lib/rules/a11y-no-generic-link-text.js
+++ b/lib/rules/a11y-no-generic-link-text.js
@@ -1,4 +1,5 @@
-const {elementType, getProp, getPropValue} = require('jsx-ast-utils')
+const {getProp, getPropValue} = require('jsx-ast-utils')
+const {getElementType} = require('../utils/get-element-type.js')
 
 const bannedLinkText = ['read more', 'here', 'click here', 'learn more', 'more', 'here']
 
@@ -23,7 +24,9 @@ module.exports = {
   create(context) {
     return {
       JSXOpeningElement: node => {
-        if (elementType(node) !== 'a') return
+        const elementType = getElementType(context, node)
+
+        if (elementType !== 'a') return
         if (getProp(node.attributes, 'aria-labelledby')) return
 
         let cleanTextContent // text content we can reliably fetch

--- a/lib/utils/get-element-type.js
+++ b/lib/utils/get-element-type.js
@@ -1,0 +1,29 @@
+const {elementType, getProp, getPropValue} = require('jsx-ast-utils')
+
+function getElementType(context, node) {
+  const {settings} = context
+  const rawElement = elementType(node)
+  if (!settings) return rawElement
+
+  const componentMap = settings['github']?.components
+  if (!componentMap) return rawElement
+  const component = componentMap[rawElement]
+  if (!component) return rawElement
+  let element = component.default ? component.default : rawElement
+
+  if (component.props) {
+    const props = Object.entries(component.props)
+    for (const [key, value] of props) {
+      const propMap = value
+      let propValue = getPropValue(getProp(node.attributes, key))
+      let mapValue = propMap[propValue]
+
+      if (mapValue) {
+        element = mapValue
+      }
+    }
+  }
+  return element
+}
+
+module.exports = {getElementType}

--- a/lib/utils/get-element-type.js
+++ b/lib/utils/get-element-type.js
@@ -12,7 +12,7 @@ function getElementType(context, node) {
   const rawElement = elementType(node)
   if (!settings) return rawElement
 
-  const componentMap = settings['github']?.components
+  const componentMap = settings.github && settings.github.components
   if (!componentMap) return rawElement
   const component = componentMap[rawElement]
   if (!component) return rawElement

--- a/lib/utils/get-element-type.js
+++ b/lib/utils/get-element-type.js
@@ -1,5 +1,12 @@
 const {elementType, getProp, getPropValue} = require('jsx-ast-utils')
 
+/*
+Allows custom component to be mapped to an element type.
+When a default is set, all instances of the component will be mapped to the default.
+If a prop determines the type, it can be specified with `props`.
+
+For now, we only support the mapping of one prop type to an element type, rather than combinations of props.
+*/
 function getElementType(context, node) {
   const {settings} = context
   const rawElement = elementType(node)

--- a/lib/utils/get-element-type.js
+++ b/lib/utils/get-element-type.js
@@ -15,8 +15,8 @@ function getElementType(context, node) {
     const props = Object.entries(component.props)
     for (const [key, value] of props) {
       const propMap = value
-      let propValue = getPropValue(getProp(node.attributes, key))
-      let mapValue = propMap[propValue]
+      const propValue = getPropValue(getProp(node.attributes, key))
+      const mapValue = propMap[propValue]
 
       if (mapValue) {
         element = mapValue

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@github/prettier-config": "0.0.4",
+        "chai": "^4.3.6",
         "eslint": "^8.0.1",
         "eslint-plugin-eslint-plugin": "^5.0.0",
         "mocha": "^10.0.0"
@@ -551,6 +552,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -683,6 +693,24 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -696,6 +724,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -846,6 +883,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/deep-is": {
@@ -1605,6 +1654,15 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -2165,6 +2223,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2550,6 +2617,15 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/picocolors": {
@@ -2984,6 +3060,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -3566,6 +3651,12 @@
         "es-abstract": "^1.19.0"
       }
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -3651,6 +3742,21 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz",
       "integrity": "sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg=="
     },
+    "chai": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3659,6 +3765,12 @@
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
@@ -3768,6 +3880,15 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "deep-is": {
       "version": "0.1.4",
@@ -4342,6 +4463,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "dev": true
+    },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -4728,6 +4855,15 @@
         "is-unicode-supported": "^0.1.0"
       }
     },
+    "loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.0"
+      }
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5004,6 +5140,12 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -5273,6 +5415,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "pretest": "mkdir -p node_modules/ && ln -fs $(pwd) node_modules/",
     "eslint-check": "eslint-config-prettier .eslintrc.js",
-    "test": "npm run eslint-check && eslint . && mocha tests/"
+    "test": "mocha ./tests/**/*.js ./tests/*.js"
   },
   "repository": {
     "type": "git",
@@ -51,6 +51,7 @@
   ],
   "devDependencies": {
     "@github/prettier-config": "0.0.4",
+    "chai": "^4.3.6",
     "eslint": "^8.0.1",
     "eslint-plugin-eslint-plugin": "^5.0.0",
     "mocha": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "pretest": "mkdir -p node_modules/ && ln -fs $(pwd) node_modules/",
     "eslint-check": "eslint-config-prettier .eslintrc.js",
-    "test": "mocha ./tests/**/*.js ./tests/*.js"
+    "test": "npm run eslint-check && eslint . && mocha tests/**/*.js tests/"
   },
   "repository": {
     "type": "git",
@@ -51,7 +51,6 @@
   ],
   "devDependencies": {
     "@github/prettier-config": "0.0.4",
-    "chai": "^4.3.6",
     "eslint": "^8.0.1",
     "eslint-plugin-eslint-plugin": "^5.0.0",
     "mocha": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   ],
   "devDependencies": {
     "@github/prettier-config": "0.0.4",
+    "chai": "^4.3.6",
     "eslint": "^8.0.1",
     "eslint-plugin-eslint-plugin": "^5.0.0",
     "mocha": "^10.0.0"

--- a/tests/a11y-no-generic-link-text.js
+++ b/tests/a11y-no-generic-link-text.js
@@ -19,9 +19,65 @@ ruleTester.run('a11y-no-generic-link-text', rule, {
     {code: "<a href='#'>GitHub Home</a>;"},
     {code: "<Box><a href='#'>GitHub Home</a></Box>;"},
     {code: "<a aria-label='Read more about our project' href='#'>Read more</a>;"},
-    {code: "<a aria-labelledby='someId' href='#'>Read more</a>;"}
+    {code: "<a aria-labelledby='someId' href='#'>Read more</a>;"},
+    {code: '<summary>Read more</summary>;'},
+    {
+      code: '<Link as="button" href="#">Read more</Link>',
+      settings: {
+        github: {
+          components: {
+            Link: {
+              props: { as: {undefined: 'a'} }
+            }
+          }
+        }
+      }
+    },
   ],
   invalid: [
+    {
+      code: '<ButtonLink href="#">Read more</ButtonLink>',
+      settings: {
+        github: {
+          components: {
+            ButtonLink: {
+              default: 'a'
+            }
+          }
+        }
+      },
+      errors:  [{message: errorMessage}]
+    },
+    {
+      code: '<Link href="#">Read more</Link>',
+      settings: {
+        github: {
+          components: {
+            Link: {
+              props: { as: {undefined: 'a'} }
+            }
+          }
+        }
+      },
+      errors:  [{message: errorMessage}]
+    },
+    {
+      code: '<Test as="a" href="#">Read more</Test>',
+      settings: {
+        github: {
+          components: {
+            Test: {
+              props: { as: {'a': 'a'} }
+            }
+          }
+        }
+      },
+      errors:  [{message: errorMessage}]
+    },
+    {
+      code: "<Box><a href='#'>Click here</a></Box>;",
+      errors: [{message: errorMessage}]
+    },
     {code: '<a>Click here*</a>;', errors: [{message: errorMessage}]},
     {code: '<a>Learn more.</a>;', errors: [{message: errorMessage}]},
     {code: "<a aria-label='read more!!!'></a>;", errors: [{message: errorMessage}]},

--- a/tests/a11y-no-generic-link-text.js
+++ b/tests/a11y-no-generic-link-text.js
@@ -27,16 +27,17 @@ ruleTester.run('a11y-no-generic-link-text', rule, {
         github: {
           components: {
             Link: {
-              props: { as: {undefined: 'a'} }
+              props: {as: {undefined: 'a'}}
             }
           }
         }
       }
-    },
+    }
   ],
   invalid: [
     {
       code: '<ButtonLink href="#">Read more</ButtonLink>',
+      errors: [{message: errorMessage}],
       settings: {
         github: {
           components: {
@@ -45,34 +46,33 @@ ruleTester.run('a11y-no-generic-link-text', rule, {
             }
           }
         }
-      },
-      errors:  [{message: errorMessage}]
+      }
     },
     {
       code: '<Link href="#">Read more</Link>',
+      errors: [{message: errorMessage}],
       settings: {
         github: {
           components: {
             Link: {
-              props: { as: {undefined: 'a'} }
+              props: {as: {undefined: 'a'}}
             }
           }
         }
-      },
-      errors:  [{message: errorMessage}]
+      }
     },
     {
       code: '<Test as="a" href="#">Read more</Test>',
+      errors: [{message: errorMessage}],
       settings: {
         github: {
           components: {
             Test: {
-              props: { as: {'a': 'a'} }
+              props: {as: {a: 'a'}}
             }
           }
         }
-      },
-      errors:  [{message: errorMessage}]
+      }
     },
     {
       code: "<Box><a href='#'>Click here</a></Box>;",

--- a/tests/utils/get-element-type.js
+++ b/tests/utils/get-element-type.js
@@ -1,0 +1,110 @@
+const {getElementType} = require('../../lib/utils/get-element-type')
+const expect = require('chai').expect
+
+function mockJSXAttribute(prop, propValue) {
+  return {
+    type: 'JSXAttribute',
+    name: {
+      type: 'JSXIdentifier',
+      name: prop
+    },
+    value: {
+      type: 'Literal',
+      value: propValue
+    }
+  }
+}
+
+function mockJSXOpeningElement(tagName, attributes = [], children = []) {
+  return {
+    type: 'JSXOpeningElement',
+    name: {
+      type: 'JSXIdentifier',
+      name: tagName
+    },
+    attributes
+  }
+}
+
+function mockSetting(componentSetting = {}) {
+  return {
+    settings: {
+      github: {
+        components: componentSetting
+      }
+    }
+  }
+}
+
+describe('getElementType', function () {
+  it('gets element type', function () {
+    const node = mockJSXOpeningElement('a')
+    expect(getElementType({}, node)).to.equal('a')
+  })
+
+  it('gets element type from default', function () {
+    const node = mockJSXOpeningElement('Link', [mockJSXAttribute('as', 'summary')])
+    const setting = mockSetting({
+      Link: {
+        default: 'button'
+      }
+    })
+    expect(getElementType(setting, node)).to.equal('button')
+  })
+
+  it('gets element type from matching props setting', function () {
+    const setting = mockSetting({
+      Link: {
+        default: 'a',
+        props: {
+          as: {summary: 'summary'}
+        }
+      }
+    })
+    const node_1 = mockJSXOpeningElement('Link')
+    expect(getElementType(setting, node_1)).to.equal('a')
+
+    const node_2 = mockJSXOpeningElement('Link', [mockJSXAttribute('as', 'p')])
+    expect(getElementType(setting, node_2)).to.equal('a')
+
+    const node_3 = mockJSXOpeningElement('Link', [mockJSXAttribute('as', 'summary')])
+    expect(getElementType(setting, node_3)).to.equal('summary')
+  })
+
+  it('uses original type if no default or matching prop setting', function () {
+    const setting = mockSetting({
+      Link: {
+        props: {
+          as: {summary: 'summary'}
+        }
+      }
+    })
+    const node = mockJSXOpeningElement('Link', [mockJSXAttribute('as', 'p')])
+    expect(getElementType(setting, node)).to.equal('Link')
+  })
+
+  it('allows undefined prop to be mapped to a type', function () {
+    const setting = mockSetting({
+      Link: {
+        props: {
+          as: {undefined: 'a'}
+        }
+      }
+    })
+    const node = mockJSXOpeningElement('Link')
+    expect(getElementType(setting, node)).to.equal('a')
+  })
+
+  it('falls back to original type if no default and prop does not match props setting', function () {
+    const setting = mockSetting({
+      Link: {
+        props: {
+          as: {undefined: 'a'}
+        }
+      }
+    })
+
+    const node = mockJSXOpeningElement('Link', [mockJSXAttribute('as', 'p')])
+    expect(getElementType(setting, node)).to.equal('Link')
+  })
+})

--- a/tests/utils/get-element-type.js
+++ b/tests/utils/get-element-type.js
@@ -1,4 +1,7 @@
 const {getElementType} = require('../../lib/utils/get-element-type')
+const mocha = require('mocha')
+const describe = mocha.describe
+const it = mocha.it
 const expect = require('chai').expect
 
 function mockJSXAttribute(prop, propValue) {
@@ -15,7 +18,7 @@ function mockJSXAttribute(prop, propValue) {
   }
 }
 
-function mockJSXOpeningElement(tagName, attributes = [], children = []) {
+function mockJSXOpeningElement(tagName, attributes = []) {
   return {
     type: 'JSXOpeningElement',
     name: {
@@ -37,12 +40,12 @@ function mockSetting(componentSetting = {}) {
 }
 
 describe('getElementType', function () {
-  it('gets element type', function () {
+  it('returns raw element type', function () {
     const node = mockJSXOpeningElement('a')
     expect(getElementType({}, node)).to.equal('a')
   })
 
-  it('gets element type from default', function () {
+  it('returns element type from default if set', function () {
     const node = mockJSXOpeningElement('Link', [mockJSXAttribute('as', 'summary')])
     const setting = mockSetting({
       Link: {
@@ -52,7 +55,7 @@ describe('getElementType', function () {
     expect(getElementType(setting, node)).to.equal('button')
   })
 
-  it('gets element type from matching props setting', function () {
+  it('returns element type from matching props setting if set', function () {
     const setting = mockSetting({
       Link: {
         default: 'a',
@@ -61,17 +64,12 @@ describe('getElementType', function () {
         }
       }
     })
-    const node_1 = mockJSXOpeningElement('Link')
-    expect(getElementType(setting, node_1)).to.equal('a')
 
-    const node_2 = mockJSXOpeningElement('Link', [mockJSXAttribute('as', 'p')])
-    expect(getElementType(setting, node_2)).to.equal('a')
-
-    const node_3 = mockJSXOpeningElement('Link', [mockJSXAttribute('as', 'summary')])
-    expect(getElementType(setting, node_3)).to.equal('summary')
+    const node = mockJSXOpeningElement('Link', [mockJSXAttribute('as', 'summary')])
+    expect(getElementType(setting, node)).to.equal('summary')
   })
 
-  it('uses original type if no default or matching prop setting', function () {
+  it('returns raw type if no default or matching prop setting', function () {
     const setting = mockSetting({
       Link: {
         props: {
@@ -95,7 +93,7 @@ describe('getElementType', function () {
     expect(getElementType(setting, node)).to.equal('a')
   })
 
-  it('falls back to original type if no default and prop does not match props setting', function () {
+  it('returns raw type if prop does not match props setting and no default type', function () {
     const setting = mockSetting({
       Link: {
         props: {


### PR DESCRIPTION
DEPENDS ON https://github.com/github/eslint-plugin-github/pull/282!
cc: @github/accessibility-reviewers

## Context 

In https://github.com/github/eslint-plugin-github/pull/282, we introduced a rule that lints against use of generic text on links.

However, this lint rule is mostly useless for GitHub developers since GitHub developers are likely to use the Primer React component, `<Link>` rather than the HTML `<a>`. We want the lint rules we write to run on Primer components too.

This PR allows for custom components to be mapped to an HTML element in the eslint configuration.

```.js
settings: {
  github: {
    components: {
      Link: {
        default: 'a'
      }
    }
  }
}
```
The above example will allow all `Link` component to be mapped to an anchor element by default. This may make sense when the tag is fixed.

However, one layer of complexity is how Primer React components also support an `as` type. To accommodate for that, the configuration should allow a mapping of a prop value of a component to an element type. 

```.js
settings: {
  github: {
    components: {
      Link: {
        props: { as: { undefined: 'a', 'a': 'a', 'button': 'button'} }
      }
    }
  }
}
```

This above setting specifies no default. It instead says that if there's a prop type of `as` and if that prop is `undefined` OR is defined and set to  `a`, the component should be mapped to an `a` tag. This ensures that if `as` is set to some other value that isn't configured in props like `summary`, we keep the raw type of `Link` (rather than defaulting to anything).

For now this config will only support one type of prop in the `props` section. I decided this might be better because combinations of props can lead to conflicts and add complexity. Also I don't see a need for supporting complicated prop specification (but let me know if there is a need for it)

## Note to reviewer

I'm open to any feedback on how this config should be shaped. 
I'm thinking that we can introduce a preset to [eslint-plugin-primer-react](https://github.com/primer/eslint-plugin-primer-react) which contains configuration for this plugin for Primer React components.