### PR TITLE
Use eslint-plugin-escompat in typescript config

### DIFF
--- a/lib/configs/typescript.js
+++ b/lib/configs/typescript.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: ['plugin:@typescript-eslint/recommended', 'prettier', 'plugin:escompat/typescript-2020'],
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'github'],
+  plugins: ['@typescript-eslint', 'escompat', 'github'],
   rules: {
     camelcase: 'off',
     'no-unused-vars': 'off',


### PR DESCRIPTION
Since upgrading to eslint-plugin-github@4.4.0, linting with the `plugin:github/typescript` config produces tons of errors indicating that definitions for the `eslint-plugin-escompat` plugin can't be found:

```
1:1   error  Definition for rule 'escompat/no-optional-chaining' was not found                                        escompat/no-optional-chaining
1:1   error  Definition for rule 'escompat/no-nullish-coalescing' was not found                                       escompat/no-nullish-coalescing
...
```

If I modify my downstream project's eslintrc to include `plugins: [..., 'escompat', ...]` and lint again, the errors go away. I think the issue is that `eslint-plugin-escompat` is a dependency of the `typescript` config for `estlint-plugin-github` but is not included in the config, so the downstream project fails trying to find it. I'm hoping this change will fix it.