### PR TITLE
Allow wildcard `*.*.*` prefix extension 

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -18,7 +18,7 @@ module.exports = {
     'eslint-comments/no-unused-disable': 'error',
     'eslint-comments/no-unused-enable': 'error',
     'eslint-comments/no-use': ['error', {allow: ['eslint', 'eslint-disable-next-line', 'eslint-env', 'globals']}],
-    'filenames/match-regex': ['error', '^[a-z0-9-]+(.d|.config|.server)?$'],
+    'filenames/match-regex': ['error', '^[a-z0-9-]+(.[a-z0-9-]+)?$'],
     'func-style': ['error', 'declaration', {allowArrowFunctions: true}],
     'github/array-foreach': 'error',
     'github/no-implicit-buggy-globals': 'error',


### PR DESCRIPTION
Follow up to https://github.com/github/eslint-plugin-github/pull/343

This change updates the recommended eslint config to generalize `filenames/match-regex` to allow any "extension prefix". For example, `file-name.wild-card.ts`

This allows any of the following:

- `file-name`
- `file-name.d`
- `file-name.config`
- `file-name.server`
- `file-name.wild-card`

Note that the actual file extension is not part of the regex.

I made this change because we are seeing more and more of this style of "extension prefix" convention. In particular I want to enable the `*.server.*` file extension introduced in https://github.com/github/github/pull/247398.