### PR TITLE
feat: `role-supports-aria-props` rule (no `aria-label`-misuse)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,32 +1,30 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.222.0/containers/javascript-node
 {
-	"name": "Node.js",
-	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
-		// Append -bullseye or -buster to pin to an OS version.
-		// Use -bullseye variants on local arm64/Apple Silicon.
-		"args": { "VARIANT": "16" }
-	},
+  "name": "Node.js",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick a Node version: 16, 14, 12.
+    // Append -bullseye or -buster to pin to an OS version.
+    // Use -bullseye variants on local arm64/Apple Silicon.
+    "args": {"VARIANT": "16"}
+  },
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
+  // Set *default* container specific settings.json values on container create.
+  "settings": {},
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"dbaeumer.vscode-eslint"
-	],
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": ["dbaeumer.vscode-eslint"],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "yarn install",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "node",
-	"features": {
-		"git": "latest"
-	}
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node",
+  "features": {
+    "git": "latest"
+  }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,11 @@
 module.exports = {
   root: true,
   parserOptions: {
-    ecmaVersion: 13
+    ecmaVersion: 13,
   },
   env: {
     es6: true,
-    node: true
+    node: true,
   },
   extends: [require.resolve('./lib/configs/recommended'), 'plugin:eslint-plugin/all'],
   plugins: ['eslint-plugin'],
@@ -15,6 +15,6 @@ module.exports = {
     'i18n-text/no-en': 'off',
     'eslint-plugin/prefer-placeholders': 'off',
     'eslint-plugin/test-case-shorthand-strings': 'off',
-    'eslint-plugin/require-meta-docs-url': 'off'
-  }
+    'eslint-plugin/require-meta-docs-url': 'off',
+  },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   parserOptions: {
-    ecmaVersion: 2020
+    ecmaVersion: 13
   },
   env: {
     es6: true,

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ This config will be interpreted in the following way:
 - [No Useless Passive](./docs/rules/no-useless-passive.md)
 - [Prefer Observers](./docs/rules/prefer-observers.md)
 - [Require Passive Events](./docs/rules/require-passive-events.md)
-- [Role Supports ARIA Props](./docs/rules/role-supports-aria-props.md)
 - [Unescaped HTML Literal](./docs/rules/unescaped-html-literal.md)
 
 #### Accessibility-focused rules (prefixed with a11y)
 
 - [No Generic Link Text](./docs/rules/a11y-no-generic-link-text.md)
+- [Role Supports ARIA Props](./docs/rules/role-supports-aria-props.md)

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ For each component, you may specify a `default` and/or `props`. `default` may ma
   "settings": {
     "github": {
       "components": {
-        "Box": { "default": "p" },
-        "Link": { "props": {"as": { "undefined": "a", "a": "a", "button": "button"}}},
+        "Box": {"default": "p"},
+        "Link": {"props": {"as": {"undefined": "a", "a": "a", "button": "button"}}}
       }
     }
   }
@@ -89,6 +89,7 @@ This config will be interpreted in the following way:
 - [No Useless Passive](./docs/rules/no-useless-passive.md)
 - [Prefer Observers](./docs/rules/prefer-observers.md)
 - [Require Passive Events](./docs/rules/require-passive-events.md)
+- [Role Supports ARIA Props](./docs/rules/role-supports-aria-props.md)
 - [Unescaped HTML Literal](./docs/rules/unescaped-html-literal.md)
 
 #### Accessibility-focused rules (prefixed with a11y)

--- a/docs/rules/a11y-no-generic-link-text.md
+++ b/docs/rules/a11y-no-generic-link-text.md
@@ -63,14 +63,18 @@ Please perform browser tests and spot checks:
 ```
 
 ```jsx
-<a href="github.com/about" aria-label="Why dogs are awesome">Read more</a>
+<a href="github.com/about" aria-label="Why dogs are awesome">
+  Read more
+</a>
 ```
 
 ```jsx
-<a href="github.com/about" aria-describedby="element123">Read more</a>
+<a href="github.com/about" aria-describedby="element123">
+  Read more
+</a>
 ```
 
-### **Correct** code for this rule  👍
+### **Correct** code for this rule 👍
 
 ```jsx
 <a href="github.com/about">Learn more about GitHub</a>

--- a/docs/rules/array-foreach.md
+++ b/docs/rules/array-foreach.md
@@ -93,6 +93,7 @@ for (const el of els) {
 ```
 
 Use [`entries()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/entries) to get access to the index:
+
 ```js
 for (const [i, el] of els.entries()) {
   el.name = `Element ${i}`

--- a/docs/rules/authenticity-token.md
+++ b/docs/rules/authenticity-token.md
@@ -33,7 +33,7 @@ on('click', '.js-my-button', function (e) {
 
   fetch(form.action, {
     method: form.method,
-    body: new FormData(form)
+    body: new FormData(form),
   }).then(function () {
     alert('Success!')
   })
@@ -52,7 +52,7 @@ An alternate, but less preferred approach is to include the a signed CSRF url in
 on('click', '.js-my-button', function (e) {
   csrfRequest(this.getAttribute('data-url'), {
     method: 'PUT',
-    body: data
+    body: data,
   }).then(function () {
     alert('Success!')
   })

--- a/docs/rules/no-useless-passive.md
+++ b/docs/rules/no-useless-passive.md
@@ -21,7 +21,7 @@ window.addEventListener(
   () => {
     console.log('Scroll event fired!')
   },
-  {passive: true}
+  {passive: true},
 )
 ```
 

--- a/docs/rules/prefer-observers.md
+++ b/docs/rules/prefer-observers.md
@@ -34,7 +34,7 @@ window.addEventListener('scroll', () => {
   const isIntersecting = checkIfElementIntersects(
     element.getBoundingClientRect(),
     window.innerHeight,
-    document.clientHeight
+    document.clientHeight,
   )
   element.classList.toggle('intersecting', isIntersecting)
 })

--- a/docs/rules/require-passive-events.md
+++ b/docs/rules/require-passive-events.md
@@ -28,7 +28,7 @@ window.addEventListener(
   () => {
     /* ... */
   },
-  {passive: true}
+  {passive: true},
 )
 ```
 

--- a/docs/rules/role-supports-aria-props.md
+++ b/docs/rules/role-supports-aria-props.md
@@ -1,0 +1,74 @@
+# Role Supports ARIA Props
+
+## Rule Details
+
+This rule enforces that elements with explicit or implicit roles defined contain only `aria-*` properties supported by that `role`.
+
+For example, this rule aims to discourage common misuse of the `aria-label` and `aria-labelledby` attribute. `aria-label` and `aria-labelledby` support is only guaranteed on interactive elements like `button` or `a`, or on static elements like `div` and `span` with a permitted `role`. This rule will allow `aria-label` and `aria-labelledby` usage on `div` and `span` elements if it set to a role other than the ones listed in [WSC: a list of ARIA roles which cannot be named](https://w3c.github.io/aria/#namefromprohibited). This rule will never permit usage of `aria-label` and `aria-labelledby` on `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `strong`, `i`, `p`, `b`, or `code`.
+
+### "Help! I'm trying to set a tooltip on a static element and this rule flagged it!"
+
+Please do not use tooltips on static elements. It is a highly discouraged, inaccessible pattern.
+See [Primer: Tooltip alternatives](https://primer.style/design/accessibility/tooltip-alternatives) for what to do instead.
+
+### Resources
+
+- [w3c/aria Consider prohibiting author naming certain roles #833](https://github.com/w3c/aria/issues/833)
+- [Not so short note on aria-label usage - Big Table Edition](https://html5accessibility.com/stuff/2020/11/07/not-so-short-note-on-aria-label-usage-big-table-edition/)
+- [Your tooltips are bogus](https://heydonworks.com/article/your-tooltips-are-bogus/)
+- [Primer: Tooltip alternatives](https://primer.style/design/accessibility/tooltip-alternatives)
+
+### Disclaimer
+
+There are conflicting resources and opinions on what elements should support these naming attributes. For now, this rule will operate under a relatively simple heuristic aimed to minimize false positives. This may have room for future improvements. Learn more at [W3C Name Calcluation](https://w3c.github.io/aria/#namecalculation).
+
+### **Incorrect** code for this rule 👎
+
+```erb
+<span class="tooltipped" aria-label="This is a tooltip">I am some text.</span>
+```
+
+```erb
+<span aria-label="This is some content that will completely override the button content">Please be careful of the following.</span>
+```
+
+```erb
+<div aria-labelledby="heading1">Goodbye</div>
+```
+
+```erb
+<h1 aria-label="This will override the page title completely">Page title</h1>
+```
+
+### **Correct** code for this rule 👍
+
+```erb
+<button aria-label="Close">
+  <svg src="closeIcon"></svg>
+</button>
+```
+
+```erb
+<button aria-label="Bold" aria-describedby="tooltip1">
+  <svg src="boldIcon"></svg>
+</button>
+<p id="tooltip1" class="tooltip">Add bold text or turn selection into bold text</p>
+```
+
+```erb
+<span>Hello</span>
+```
+
+```erb
+<div>Goodbye</div>
+```
+
+```erb
+<h1>Page title</h1>
+```
+
+```erb
+<div role="dialog" aria-labelledby="dialogHeading">
+  <h1 id="dialogHeading">Heading</h1>
+</div>
+```

--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -2,14 +2,14 @@ module.exports = {
   parserOptions: {
     sourceType: 'module',
     ecmaFeatures: {
-      jsx: true
-    }
+      jsx: true,
+    },
   },
   plugins: ['github', 'jsx-a11y'],
   extends: ['plugin:jsx-a11y/recommended'],
   rules: {
     'github/a11y-no-generic-link-text': 'error',
     'github/role-supports-aria-props': 'error',
-    'jsx-a11y/role-supports-aria-props': 'off'
-  }
+    'jsx-a11y/role-supports-aria-props': 'off',
+  },
 }

--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -8,6 +8,8 @@ module.exports = {
   plugins: ['github', 'jsx-a11y'],
   extends: ['plugin:jsx-a11y/recommended'],
   rules: {
-    'github/a11y-no-generic-link-text': 'error'
+    'github/a11y-no-generic-link-text': 'error',
+    'github/role-supports-aria-props': 'error',
+    'jsx-a11y/role-supports-aria-props': 'off'
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'no-then': require('./rules/no-then'),
     'no-useless-passive': require('./rules/no-useless-passive'),
     'prefer-observers': require('./rules/prefer-observers'),
+    'role-supports-aria-props': require('./rules/role-supports-aria-props'),
     'require-passive-events': require('./rules/require-passive-events'),
     'unescaped-html-literal': require('./rules/unescaped-html-literal')
   },

--- a/lib/rules/role-supports-aria-props.js
+++ b/lib/rules/role-supports-aria-props.js
@@ -29,9 +29,9 @@ module.exports = {
     docs: {
       description:
         'Enforce that elements with explicit or implicit roles defined contain only `aria-*` properties supported by that `role`.',
-      url: require('../url')(module)
+      url: require('../url')(module),
     },
-    schema: []
+    schema: [],
   },
 
   create(context) {
@@ -91,11 +91,11 @@ module.exports = {
           if (prohibitedProps?.includes(propName(prop))) {
             context.report({
               node,
-              message: `The attribute ${propName(prop)} is not supported by the role ${role}.`
+              message: `The attribute ${propName(prop)} is not supported by the role ${role}.`,
             })
           }
         }
-      }
+      },
     }
-  }
+  },
 }

--- a/lib/rules/role-supports-aria-props.js
+++ b/lib/rules/role-supports-aria-props.js
@@ -7,15 +7,22 @@ const ObjectMap = require('../utils/object-map')
 // Clean-up `elementRoles` from `aria-query`
 const elementRolesMap = new ObjectMap()
 for (const [key, value] of elementRoles.entries()) {
+  // - Remove unused `constraints` key
   delete key.constraints
   key.attributes = key.attributes?.filter(attribute => !('constraints' in attribute))
+  // - Remove empty `attributes` key
   if (!key.attributes || key.attributes?.length === 0) {
     delete key.attributes
   }
   elementRolesMap.set(key, value)
 }
+// - Remove insufficiently-disambiguated `menuitem` entry
 elementRolesMap.delete({name: 'menuitem'})
+// - Disambiguate `menuitem` and `menu` roles by `type`
+elementRolesMap.set({name: 'menuitem', attributes: [{name: 'type', value: 'command'}]}, ['menuitem'])
+elementRolesMap.set({name: 'menuitem', attributes: [{name: 'type', value: 'radio'}]}, ['menuitemradio'])
 elementRolesMap.set({name: 'menuitem', attributes: [{name: 'type', value: 'toolbar'}]}, ['toolbar'])
+elementRolesMap.set({name: 'menu', attributes: [{name: 'type', value: 'toolbar'}]}, ['toolbar'])
 
 module.exports = {
   meta: {
@@ -30,14 +37,18 @@ module.exports = {
   create(context) {
     return {
       JSXOpeningElement(node) {
-        // Get the element’s explicit or implicit role
+        // Assemble a key for looking-up the element’s role in the `elementRolesMap`
+        // - Get the element’s name
         const key = {name: getElementType(context, node)}
+        // - Get the element’s disambiguating attributes
         for (const prop of ['aria-expanded', 'type', 'size', 'role', 'href', 'multiple', 'scope']) {
+          // - Only provide `aria-expanded` when it’s required for disambiguation
+          if (prop === 'aria-expanded' && key.name !== 'summary') continue
           const value = getPropValue(getProp(node.attributes, prop))
-          if (!('attributes' in key)) {
-            key.attributes = []
-          }
           if (value) {
+            if (!('attributes' in key)) {
+              key.attributes = []
+            }
             if (prop === 'href') {
               key.attributes.push({name: prop})
             } else {
@@ -45,6 +56,7 @@ module.exports = {
             }
           }
         }
+        // Get the element’s explicit or implicit role
         const role = getPropValue(getProp(node.attributes, 'role')) ?? elementRolesMap.get(key)?.[0]
 
         // Return early if role could not be determined
@@ -73,6 +85,7 @@ module.exports = {
         prohibitedProps = Array.from(new Set(prohibitedProps))
 
         for (const prop of node.attributes) {
+          // Return early if prohibited ARIA attribute is set to an ignorable value
           if (getPropValue(prop) == null || prop.type === 'JSXSpreadAttribute') return
 
           if (prohibitedProps?.includes(propName(prop))) {

--- a/lib/rules/role-supports-aria-props.js
+++ b/lib/rules/role-supports-aria-props.js
@@ -1,0 +1,88 @@
+// @ts-check
+const {aria, elementRoles, roles} = require('aria-query')
+const {getProp, getPropValue, propName} = require('jsx-ast-utils')
+const {getElementType} = require('../utils/get-element-type')
+const ObjectMap = require('../utils/object-map')
+
+// Clean-up `elementRoles` from `aria-query`
+const elementRolesMap = new ObjectMap()
+for (const [key, value] of elementRoles.entries()) {
+  delete key.constraints
+  key.attributes = key.attributes?.filter(attribute => !('constraints' in attribute))
+  if (!key.attributes || key.attributes?.length === 0) {
+    delete key.attributes
+  }
+  elementRolesMap.set(key, value)
+}
+elementRolesMap.delete({name: 'menuitem'})
+elementRolesMap.set({name: 'menuitem', attributes: [{name: 'type', value: 'toolbar'}]}, ['toolbar'])
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Enforce that elements with explicit or implicit roles defined contain only `aria-*` properties supported by that `role`.',
+      url: require('../url')(module)
+    },
+    schema: []
+  },
+
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        // Get the element’s explicit or implicit role
+        const key = {name: getElementType(context, node)}
+        for (const prop of ['aria-expanded', 'type', 'size', 'role', 'href', 'multiple', 'scope']) {
+          const value = getPropValue(getProp(node.attributes, prop))
+          if (!('attributes' in key)) {
+            key.attributes = []
+          }
+          if (value) {
+            if (prop === 'href') {
+              key.attributes.push({name: prop})
+            } else {
+              key.attributes.push({name: prop, value})
+            }
+          }
+        }
+        const role = getPropValue(getProp(node.attributes, 'role')) ?? elementRolesMap.get(key)?.[0]
+
+        // Return early if role could not be determined
+        if (!role) return
+
+        // Get allowed ARIA attributes:
+        // - From the role itself
+        let allowedProps = Object.keys(roles.get(role)?.props || {})
+        // - From parent roles
+        for (const parentRole of roles.get(role)?.superClass.flat() ?? []) {
+          allowedProps = allowedProps.concat(Object.keys(roles.get(parentRole)?.props || {}))
+        }
+        // Dedupe, for performance
+        allowedProps = Array.from(new Set(allowedProps))
+
+        // Get prohibited ARIA attributes:
+        // - From the role itself
+        let prohibitedProps = roles.get(role)?.prohibitedProps || []
+        // - From parent roles
+        for (const parentRole of roles.get(role)?.superClass.flat() ?? []) {
+          prohibitedProps = prohibitedProps.concat(roles.get(parentRole)?.prohibitedProps || [])
+        }
+        // - From comparing allowed vs all ARIA attributes
+        prohibitedProps = prohibitedProps.concat(aria.keys().filter(x => !allowedProps.includes(x)))
+        // Dedupe, for performance
+        prohibitedProps = Array.from(new Set(prohibitedProps))
+
+        for (const prop of node.attributes) {
+          if (getPropValue(prop) == null || prop.type === 'JSXSpreadAttribute') return
+
+          if (prohibitedProps?.includes(propName(prop))) {
+            context.report({
+              node,
+              message: `The attribute ${propName(prop)} is not supported by the role ${role}.`
+            })
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/utils/object-map.js
+++ b/lib/utils/object-map.js
@@ -1,0 +1,58 @@
+// @ts-check
+const {isDeepStrictEqual} = require('util')
+
+/**
+ * ObjectMap extends Map, but determines key equality using Node.js’ `util.isDeepStrictEqual` rather than using [SameValueZero](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#key_equality). This makes using objects as keys a bit simpler.
+ */
+module.exports = class ObjectMap extends Map {
+  #data
+
+  constructor(iterable = []) {
+    super()
+    this.#data = iterable
+  }
+
+  clear() {
+    this.#data = []
+  }
+
+  delete(key) {
+    if (!this.has(key)) {
+      return false
+    }
+    this.#data = this.#data.filter(([existingKey]) => !isDeepStrictEqual(existingKey, key))
+    return true
+  }
+
+  entries() {
+    return this.#data[Symbol.iterator]()
+  }
+
+  forEach(cb) {
+    for (const [key, value] of this.#data) {
+      cb(value, key, this.#data)
+    }
+  }
+
+  get(key) {
+    return this.#data.find(([existingKey]) => isDeepStrictEqual(existingKey, key))?.[1]
+  }
+
+  has(key) {
+    return this.#data.findIndex(([existingKey]) => isDeepStrictEqual(existingKey, key)) !== -1
+  }
+
+  keys() {
+    return this.#data.map(([key]) => key)[Symbol.iterator]()
+  }
+
+  set(key, value) {
+    this.delete(key)
+    this.#data.push([key, value])
+    return this
+  }
+
+  values() {
+    return this.#data.map(([, value]) => value)[Symbol.iterator]()
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@github/browserslist-config": "^1.0.0",
         "@typescript-eslint/eslint-plugin": "^5.1.0",
         "@typescript-eslint/parser": "^5.1.0",
+        "aria-query": "^5.1.3",
         "eslint-config-prettier": ">=8.0.0",
         "eslint-plugin-escompat": "^3.3.3",
         "eslint-plugin-eslint-comments": "^3.2.0",
@@ -52,12 +53,12 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.18.9.tgz",
-      "integrity": "sha512-qZEWeccZCrHA2Au4/X05QW5CMdm4VjUDCrGq5gf1ZDcM4hRqreKrtwAn7yci9zfgAS9apvnsFXiGBHBAxZdK9A==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.6.tgz",
+      "integrity": "sha512-tqeujPiuEfcH067mx+7otTQWROVMKHXEaOQcAeNV5dDdbPWvPcFA8/W9LXw2NfjNmOetqLl03dfnG2WALPlsRQ==",
       "dependencies": {
-        "core-js-pure": "^3.20.2",
-        "regenerator-runtime": "^0.13.4"
+        "core-js-pure": "^3.25.1",
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -522,15 +523,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
-      },
-      "engines": {
-        "node": ">=6.0"
+        "deep-equal": "^2.0.5"
       }
     },
     "node_modules/array-includes": {
@@ -588,6 +585,17 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/axe-core": {
       "version": "4.4.3",
@@ -853,9 +861,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/core-js-pure": {
-      "version": "3.23.5",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.23.5.tgz",
-      "integrity": "sha512-8t78LdpKSuCq4pJYCYk8hl7XEkAX+BP16yRIwL3AanTksxuEf7CM83vRyctmiEL8NDZ3jpUcv56fk9/zG3aIuw==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.1.tgz",
+      "integrity": "sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -918,6 +926,31 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.1.0.tgz",
+      "integrity": "sha512-2pxgvWu3Alv1PoWEyVg7HS8YhGlUFUV7N5oOvfL6d+7xAmLSemMwv/c8Zv/i9KFzxV5Kt5CAvQc70fLwVuf4UA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.2",
+        "get-intrinsic": "^1.1.3",
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/deep-is": {
@@ -1013,6 +1046,24 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
+      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.0",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.1.0",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1314,6 +1365,18 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
+      },
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
@@ -1686,6 +1749,14 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1754,13 +1825,13 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1842,6 +1913,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/grapheme-splitter": {
@@ -1979,6 +2061,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -2072,6 +2169,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -2137,6 +2242,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -2176,6 +2289,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -2188,6 +2319,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -2198,6 +2337,23 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2588,6 +2744,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -2597,9 +2768,9 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
-      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -2838,9 +3009,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -3283,6 +3454,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -3443,12 +3647,12 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.18.9.tgz",
-      "integrity": "sha512-qZEWeccZCrHA2Au4/X05QW5CMdm4VjUDCrGq5gf1ZDcM4hRqreKrtwAn7yci9zfgAS9apvnsFXiGBHBAxZdK9A==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.6.tgz",
+      "integrity": "sha512-tqeujPiuEfcH067mx+7otTQWROVMKHXEaOQcAeNV5dDdbPWvPcFA8/W9LXw2NfjNmOetqLl03dfnG2WALPlsRQ==",
       "requires": {
-        "core-js-pure": "^3.20.2",
-        "regenerator-runtime": "^0.13.4"
+        "core-js-pure": "^3.25.1",
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@eslint/eslintrc": {
@@ -3734,12 +3938,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "requires": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
+        "deep-equal": "^2.0.5"
       }
     },
     "array-includes": {
@@ -3779,6 +3982,11 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "axe-core": {
       "version": "4.4.3",
@@ -3966,9 +4174,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-js-pure": {
-      "version": "3.23.5",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.23.5.tgz",
-      "integrity": "sha512-8t78LdpKSuCq4pJYCYk8hl7XEkAX+BP16yRIwL3AanTksxuEf7CM83vRyctmiEL8NDZ3jpUcv56fk9/zG3aIuw=="
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.1.tgz",
+      "integrity": "sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -4006,6 +4214,28 @@
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.1.0.tgz",
+      "integrity": "sha512-2pxgvWu3Alv1PoWEyVg7HS8YhGlUFUV7N5oOvfL6d+7xAmLSemMwv/c8Zv/i9KFzxV5Kt5CAvQc70fLwVuf4UA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.2",
+        "get-intrinsic": "^1.1.3",
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.8"
       }
     },
     "deep-is": {
@@ -4083,6 +4313,21 @@
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
+      }
+    },
+    "es-get-iterator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
+      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.0",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.1.0",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
       }
     },
     "es-to-primitive": {
@@ -4376,6 +4621,15 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
+        "aria-query": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+          "requires": {
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
+          }
+        },
         "emoji-regex": {
           "version": "9.2.2",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -4579,6 +4833,14 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4625,13 +4887,13 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
     },
     "get-symbol-description": {
@@ -4683,6 +4945,14 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "grapheme-splitter": {
@@ -4778,6 +5048,15 @@
         "side-channel": "^1.0.4"
       }
     },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -4838,6 +5117,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
+    },
     "is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -4876,6 +5160,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
+    },
     "is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -4900,11 +5189,28 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
+    },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -4913,6 +5219,20 @@
       "requires": {
         "call-bind": "^1.0.2"
       }
+    },
+    "is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -5213,15 +5533,24 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
     },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
-      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -5377,9 +5706,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
@@ -5653,6 +5982,30 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@github/browserslist-config": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^5.1.0",
     "@typescript-eslint/parser": "^5.1.0",
+    "aria-query": "^5.1.3",
     "eslint-config-prettier": ">=8.0.0",
     "eslint-plugin-escompat": "^3.3.3",
     "eslint-plugin-eslint-comments": "^3.2.0",

--- a/tests/role-supports-aria-props.js
+++ b/tests/role-supports-aria-props.js
@@ -1,0 +1,511 @@
+// @ts-check
+const rule = require('../lib/rules/role-supports-aria-props')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+})
+
+function getErrorMessage(attribute, role) {
+  return `The attribute ${attribute} is not supported by the role ${role}.`
+}
+
+ruleTester.run('role-supports-aria-props', rule, {
+  valid: [
+    {code: '<Foo bar />'},
+    {code: '<div />'},
+    {code: '<div id="main" />'},
+    {code: '<div role />'},
+    {code: '<div role="presentation" {...props} />'},
+    {code: '<Foo.Bar baz={true} />'},
+    {code: '<Link href="#" aria-checked />'},
+
+    // IMPLICIT ROLE TESTS
+    // A TESTS - implicit role is `link`
+    {code: '<a href="#" aria-expanded />'},
+    {code: '<a href="#" aria-atomic />'},
+    {code: '<a href="#" aria-busy />'},
+    {code: '<a href="#" aria-controls />'},
+    {code: '<a href="#" aria-current />'},
+    {code: '<a href="#" aria-describedby />'},
+    {code: '<a href="#" aria-disabled />'},
+    {code: '<a href="#" aria-dropeffect />'},
+    {code: '<a href="#" aria-flowto />'},
+    {code: '<a href="#" aria-haspopup />'},
+    {code: '<a href="#" aria-grabbed />'},
+    {code: '<a href="#" aria-hidden />'},
+    {code: '<a href="#" aria-label />'},
+    {code: '<a href="#" aria-labelledby />'},
+    {code: '<a href="#" aria-live />'},
+    {code: '<a href="#" aria-owns />'},
+    {code: '<a href="#" aria-relevant />'},
+
+    // this will have global
+    {code: '<a aria-checked />'},
+
+    // AREA TESTS - implicit role is `link`
+    {code: '<area href="#" aria-expanded />'},
+    {code: '<area href="#" aria-atomic />'},
+    {code: '<area href="#" aria-busy />'},
+    {code: '<area href="#" aria-controls />'},
+    {code: '<area href="#" aria-describedby />'},
+    {code: '<area href="#" aria-disabled />'},
+    {code: '<area href="#" aria-dropeffect />'},
+    {code: '<area href="#" aria-flowto />'},
+    {code: '<area href="#" aria-grabbed />'},
+    {code: '<area href="#" aria-haspopup />'},
+    {code: '<area href="#" aria-hidden />'},
+    {code: '<area href="#" aria-label />'},
+    {code: '<area href="#" aria-labelledby />'},
+    {code: '<area href="#" aria-live />'},
+    {code: '<area href="#" aria-owns />'},
+    {code: '<area href="#" aria-relevant />'},
+
+    // this will have global
+    {code: '<area aria-checked />'},
+
+    // LINK TESTS - implicit role is `link`
+    {code: '<link href="#" aria-expanded />'},
+    {code: '<link href="#" aria-atomic />'},
+    {code: '<link href="#" aria-busy />'},
+    {code: '<link href="#" aria-controls />'},
+    {code: '<link href="#" aria-describedby />'},
+    {code: '<link href="#" aria-disabled />'},
+    {code: '<link href="#" aria-dropeffect />'},
+    {code: '<link href="#" aria-flowto />'},
+    {code: '<link href="#" aria-grabbed />'},
+    {code: '<link href="#" aria-hidden />'},
+    {code: '<link href="#" aria-haspopup />'},
+    {code: '<link href="#" aria-label />'},
+    {code: '<link href="#" aria-labelledby />'},
+    {code: '<link href="#" aria-live />'},
+    {code: '<link href="#" aria-owns />'},
+    {code: '<link href="#" aria-relevant />'},
+
+    // this will have global
+    {code: '<link aria-checked />'},
+
+    // IMG TESTS - no implicit role
+    {code: '<img alt="" aria-checked />'},
+
+    // this will have role of `img`
+    {code: '<img alt="foobar" aria-busy />'},
+
+    // MENU TESTS - implicit role is `toolbar` when `type="toolbar"`
+    {code: '<menu type="toolbar" aria-activedescendant />'},
+    {code: '<menu type="toolbar" aria-atomic />'},
+    {code: '<menu type="toolbar" aria-busy />'},
+    {code: '<menu type="toolbar" aria-controls />'},
+    {code: '<menu type="toolbar" aria-describedby />'},
+    {code: '<menu type="toolbar" aria-disabled />'},
+    {code: '<menu type="toolbar" aria-dropeffect />'},
+    {code: '<menu type="toolbar" aria-flowto />'},
+    {code: '<menu type="toolbar" aria-grabbed />'},
+    {code: '<menu type="toolbar" aria-hidden />'},
+    {code: '<menu type="toolbar" aria-label />'},
+    {code: '<menu type="toolbar" aria-labelledby />'},
+    {code: '<menu type="toolbar" aria-live />'},
+    {code: '<menu type="toolbar" aria-owns />'},
+    {code: '<menu type="toolbar" aria-relevant />'},
+
+    // this will have global
+    {code: '<menu aria-checked />'},
+
+    // MENUITEM TESTS
+    // when `type="command`, the implicit role is `menuitem`
+    {code: '<menuitem type="command" aria-atomic />'},
+    {code: '<menuitem type="command" aria-busy />'},
+    {code: '<menuitem type="command" aria-controls />'},
+    {code: '<menuitem type="command" aria-describedby />'},
+    {code: '<menuitem type="command" aria-disabled />'},
+    {code: '<menuitem type="command" aria-dropeffect />'},
+    {code: '<menuitem type="command" aria-flowto />'},
+    {code: '<menuitem type="command" aria-grabbed />'},
+    {code: '<menuitem type="command" aria-haspopup />'},
+    {code: '<menuitem type="command" aria-hidden />'},
+    {code: '<menuitem type="command" aria-label />'},
+    {code: '<menuitem type="command" aria-labelledby />'},
+    {code: '<menuitem type="command" aria-live />'},
+    {code: '<menuitem type="command" aria-owns />'},
+    {code: '<menuitem type="command" aria-relevant />'},
+    // when `type="checkbox`, the implicit role is `menuitemcheckbox`
+    {code: '<menuitem type="checkbox" aria-checked />'},
+    {code: '<menuitem type="checkbox" aria-atomic />'},
+    {code: '<menuitem type="checkbox" aria-busy />'},
+    {code: '<menuitem type="checkbox" aria-controls />'},
+    {code: '<menuitem type="checkbox" aria-describedby />'},
+    {code: '<menuitem type="checkbox" aria-disabled />'},
+    {code: '<menuitem type="checkbox" aria-dropeffect />'},
+    {code: '<menuitem type="checkbox" aria-flowto />'},
+    {code: '<menuitem type="checkbox" aria-grabbed />'},
+    {code: '<menuitem type="checkbox" aria-haspopup />'},
+    {code: '<menuitem type="checkbox" aria-hidden />'},
+    {code: '<menuitem type="checkbox" aria-invalid />'},
+    {code: '<menuitem type="checkbox" aria-label />'},
+    {code: '<menuitem type="checkbox" aria-labelledby />'},
+    {code: '<menuitem type="checkbox" aria-live />'},
+    {code: '<menuitem type="checkbox" aria-owns />'},
+    {code: '<menuitem type="checkbox" aria-relevant />'},
+    // when `type="radio`, the implicit role is `menuitemradio`
+    {code: '<menuitem type="radio" aria-checked />'},
+    {code: '<menuitem type="radio" aria-atomic />'},
+    {code: '<menuitem type="radio" aria-busy />'},
+    {code: '<menuitem type="radio" aria-controls />'},
+    {code: '<menuitem type="radio" aria-describedby />'},
+    {code: '<menuitem type="radio" aria-disabled />'},
+    {code: '<menuitem type="radio" aria-dropeffect />'},
+    {code: '<menuitem type="radio" aria-flowto />'},
+    {code: '<menuitem type="radio" aria-grabbed />'},
+    {code: '<menuitem type="radio" aria-haspopup />'},
+    {code: '<menuitem type="radio" aria-hidden />'},
+    {code: '<menuitem type="radio" aria-invalid />'},
+    {code: '<menuitem type="radio" aria-label />'},
+    {code: '<menuitem type="radio" aria-labelledby />'},
+    {code: '<menuitem type="radio" aria-live />'},
+    {code: '<menuitem type="radio" aria-owns />'},
+    {code: '<menuitem type="radio" aria-relevant />'},
+    {code: '<menuitem type="radio" aria-posinset />'},
+    {code: '<menuitem type="radio" aria-setsize />'},
+
+    // these will have global
+    {code: '<menuitem aria-checked />'},
+    {code: '<menuitem type="foo" aria-checked />'},
+
+    // INPUT TESTS
+    // when `type="button"`, the implicit role is `button`
+    {code: '<input type="button" aria-expanded />'},
+    {code: '<input type="button" aria-pressed />'},
+    {code: '<input type="button" aria-atomic />'},
+    {code: '<input type="button" aria-busy />'},
+    {code: '<input type="button" aria-controls />'},
+    {code: '<input type="button" aria-describedby />'},
+    {code: '<input type="button" aria-disabled />'},
+    {code: '<input type="button" aria-dropeffect />'},
+    {code: '<input type="button" aria-flowto />'},
+    {code: '<input type="button" aria-grabbed />'},
+    {code: '<input type="button" aria-haspopup />'},
+    {code: '<input type="button" aria-hidden />'},
+    {code: '<input type="button" aria-label />'},
+    {code: '<input type="button" aria-labelledby />'},
+    {code: '<input type="button" aria-live />'},
+    {code: '<input type="button" aria-owns />'},
+    {code: '<input type="button" aria-relevant />'},
+    // when `type="image"`, the implicit role is `button`
+    {code: '<input type="image" aria-expanded />'},
+    {code: '<input type="image" aria-pressed />'},
+    {code: '<input type="image" aria-atomic />'},
+    {code: '<input type="image" aria-busy />'},
+    {code: '<input type="image" aria-controls />'},
+    {code: '<input type="image" aria-describedby />'},
+    {code: '<input type="image" aria-disabled />'},
+    {code: '<input type="image" aria-dropeffect />'},
+    {code: '<input type="image" aria-flowto />'},
+    {code: '<input type="image" aria-grabbed />'},
+    {code: '<input type="image" aria-haspopup />'},
+    {code: '<input type="image" aria-hidden />'},
+    {code: '<input type="image" aria-label />'},
+    {code: '<input type="image" aria-labelledby />'},
+    {code: '<input type="image" aria-live />'},
+    {code: '<input type="image" aria-owns />'},
+    {code: '<input type="image" aria-relevant />'},
+    // when `type="reset"`, the implicit role is `button`
+    {code: '<input type="reset" aria-expanded />'},
+    {code: '<input type="reset" aria-pressed />'},
+    {code: '<input type="reset" aria-atomic />'},
+    {code: '<input type="reset" aria-busy />'},
+    {code: '<input type="reset" aria-controls />'},
+    {code: '<input type="reset" aria-describedby />'},
+    {code: '<input type="reset" aria-disabled />'},
+    {code: '<input type="reset" aria-dropeffect />'},
+    {code: '<input type="reset" aria-flowto />'},
+    {code: '<input type="reset" aria-grabbed />'},
+    {code: '<input type="reset" aria-haspopup />'},
+    {code: '<input type="reset" aria-hidden />'},
+    {code: '<input type="reset" aria-label />'},
+    {code: '<input type="reset" aria-labelledby />'},
+    {code: '<input type="reset" aria-live />'},
+    {code: '<input type="reset" aria-owns />'},
+    {code: '<input type="reset" aria-relevant />'},
+    // when `type="submit"`, the implicit role is `button`
+    {code: '<input type="submit" aria-expanded />'},
+    {code: '<input type="submit" aria-pressed />'},
+    {code: '<input type="submit" aria-atomic />'},
+    {code: '<input type="submit" aria-busy />'},
+    {code: '<input type="submit" aria-controls />'},
+    {code: '<input type="submit" aria-describedby />'},
+    {code: '<input type="submit" aria-disabled />'},
+    {code: '<input type="submit" aria-dropeffect />'},
+    {code: '<input type="submit" aria-flowto />'},
+    {code: '<input type="submit" aria-grabbed />'},
+    {code: '<input type="submit" aria-haspopup />'},
+    {code: '<input type="submit" aria-hidden />'},
+    {code: '<input type="submit" aria-label />'},
+    {code: '<input type="submit" aria-labelledby />'},
+    {code: '<input type="submit" aria-live />'},
+    {code: '<input type="submit" aria-owns />'},
+    {code: '<input type="submit" aria-relevant />'},
+    // when `type="checkbox"`, the implicit role is `checkbox`
+    {code: '<input type="checkbox" aria-atomic />'},
+    {code: '<input type="checkbox" aria-busy />'},
+    {code: '<input type="checkbox" aria-checked />'},
+    {code: '<input type="checkbox" aria-controls />'},
+    {code: '<input type="checkbox" aria-describedby />'},
+    {code: '<input type="checkbox" aria-disabled />'},
+    {code: '<input type="checkbox" aria-dropeffect />'},
+    {code: '<input type="checkbox" aria-flowto />'},
+    {code: '<input type="checkbox" aria-grabbed />'},
+    {code: '<input type="checkbox" aria-hidden />'},
+    {code: '<input type="checkbox" aria-invalid />'},
+    {code: '<input type="checkbox" aria-label />'},
+    {code: '<input type="checkbox" aria-labelledby />'},
+    {code: '<input type="checkbox" aria-live />'},
+    {code: '<input type="checkbox" aria-owns />'},
+    {code: '<input type="checkbox" aria-relevant />'},
+    // when `type="radio"`, the implicit role is `radio`
+    {code: '<input type="radio" aria-atomic />'},
+    {code: '<input type="radio" aria-busy />'},
+    {code: '<input type="radio" aria-checked />'},
+    {code: '<input type="radio" aria-controls />'},
+    {code: '<input type="radio" aria-describedby />'},
+    {code: '<input type="radio" aria-disabled />'},
+    {code: '<input type="radio" aria-dropeffect />'},
+    {code: '<input type="radio" aria-flowto />'},
+    {code: '<input type="radio" aria-grabbed />'},
+    {code: '<input type="radio" aria-hidden />'},
+    {code: '<input type="radio" aria-label />'},
+    {code: '<input type="radio" aria-labelledby />'},
+    {code: '<input type="radio" aria-live />'},
+    {code: '<input type="radio" aria-owns />'},
+    {code: '<input type="radio" aria-relevant />'},
+    {code: '<input type="radio" aria-posinset />'},
+    {code: '<input type="radio" aria-setsize />'},
+    // when `type="range"`, the implicit role is `slider`
+    {code: '<input type="range" aria-valuemax />'},
+    {code: '<input type="range" aria-valuemin />'},
+    {code: '<input type="range" aria-valuenow />'},
+    {code: '<input type="range" aria-orientation />'},
+    {code: '<input type="range" aria-atomic />'},
+    {code: '<input type="range" aria-busy />'},
+    {code: '<input type="range" aria-controls />'},
+    {code: '<input type="range" aria-describedby />'},
+    {code: '<input type="range" aria-disabled />'},
+    {code: '<input type="range" aria-dropeffect />'},
+    {code: '<input type="range" aria-flowto />'},
+    {code: '<input type="range" aria-grabbed />'},
+    {code: '<input type="range" aria-haspopup />'},
+    {code: '<input type="range" aria-hidden />'},
+    {code: '<input type="range" aria-invalid />'},
+    {code: '<input type="range" aria-label />'},
+    {code: '<input type="range" aria-labelledby />'},
+    {code: '<input type="range" aria-live />'},
+    {code: '<input type="range" aria-owns />'},
+    {code: '<input type="range" aria-relevant />'},
+    {code: '<input type="range" aria-valuetext />'},
+
+    // these will have role of `textbox`,
+    {code: '<input type="email" aria-disabled />'},
+    {code: '<input type="password" aria-disabled />'},
+    {code: '<input type="search" aria-disabled />'},
+    {code: '<input type="tel" aria-disabled />'},
+    {code: '<input type="url" aria-disabled />'},
+    {code: '<input aria-disabled />'},
+
+    // Allow null/undefined values regardless of role
+    {code: '<h2 role="presentation" aria-level={null} />'},
+    {code: '<h2 role="presentation" aria-level={undefined} />'},
+
+    // OTHER TESTS
+    {code: '<button aria-pressed />'},
+    {code: '<form aria-hidden />'},
+    {code: '<h1 aria-hidden />'},
+    {code: '<h2 aria-hidden />'},
+    {code: '<h3 aria-hidden />'},
+    {code: '<h4 aria-hidden />'},
+    {code: '<h5 aria-hidden />'},
+    {code: '<h6 aria-hidden />'},
+    {code: '<hr aria-hidden />'},
+    {code: '<li aria-current />'},
+    {code: '<meter aria-atomic />'},
+    {code: '<option aria-atomic />'},
+    {code: '<progress aria-atomic />'},
+    {code: '<textarea aria-hidden />'},
+    {code: '<select aria-expanded />'},
+    {code: '<datalist aria-expanded />'},
+    {code: '<div role="heading" aria-level />'},
+    {code: '<div role="heading" aria-level="1" />'}
+  ],
+
+  invalid: [
+    // implicit basic checks
+    {
+      code: '<a href="#" aria-checked />',
+      errors: [getErrorMessage('aria-checked', 'link')]
+    },
+    {
+      code: '<area href="#" aria-checked />',
+      errors: [getErrorMessage('aria-checked', 'link')]
+    },
+    {
+      code: '<link href="#" aria-checked />',
+      errors: [getErrorMessage('aria-checked', 'link')]
+    },
+    {
+      code: '<img alt="foobar" aria-checked />',
+      errors: [getErrorMessage('aria-checked', 'img')]
+    },
+    {
+      code: '<menu type="toolbar" aria-checked />',
+      errors: [getErrorMessage('aria-checked', 'toolbar')]
+    },
+    {
+      code: '<aside aria-checked />',
+      errors: [getErrorMessage('aria-checked', 'complementary')]
+    },
+    {
+      code: '<ul aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'list')]
+    }
+    // {
+    //   code: '<details aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'group')]
+    // },
+    // {
+    //   code: '<dialog aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'dialog')]
+    // },
+    // {
+    //   code: '<aside aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'complementary')]
+    // },
+    // {
+    //   code: '<article aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'article')]
+    // },
+    // {
+    //   code: '<body aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'document')]
+    // },
+    // {
+    //   code: '<li aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'listitem')]
+    // },
+    // {
+    //   code: '<nav aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'navigation')]
+    // },
+    // {
+    //   code: '<ol aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'list')]
+    // },
+    // {
+    //   code: '<output aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'status')]
+    // },
+    // {
+    //   code: '<section aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'region')]
+    // },
+    // {
+    //   code: '<tbody aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'rowgroup')]
+    // },
+    // {
+    //   code: '<tfoot aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'rowgroup')]
+    // },
+    // {
+    //   code: '<thead aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'rowgroup')]
+    // },
+    // {
+    //   code: '<input type="radio" aria-invalid />',
+    //   errors: [getErrorMessage('aria-invalid', 'radio')]
+    // },
+    // {
+    //   code: '<input type="radio" aria-selected />',
+    //   errors: [getErrorMessage('aria-selected', 'radio')]
+    // },
+    // {
+    //   code: '<input type="radio" aria-haspopup />',
+    //   errors: [getErrorMessage('aria-haspopup', 'radio')]
+    // },
+    // {
+    //   code: '<input type="checkbox" aria-haspopup />',
+    //   errors: [getErrorMessage('aria-haspopup', 'checkbox')]
+    // },
+    // {
+    //   code: '<input type="reset" aria-invalid />',
+    //   errors: [getErrorMessage('aria-invalid', 'button')]
+    // },
+    // {
+    //   code: '<input type="submit" aria-invalid />',
+    //   errors: [getErrorMessage('aria-invalid', 'button')]
+    // },
+    // {
+    //   code: '<input type="image" aria-invalid />',
+    //   errors: [getErrorMessage('aria-invalid', 'button')]
+    // },
+    // {
+    //   code: '<input type="button" aria-invalid />',
+    //   errors: [getErrorMessage('aria-invalid', 'button')]
+    // },
+    // {
+    //   code: '<menuitem type="command" aria-invalid />',
+    //   errors: [getErrorMessage('aria-invalid', 'menuitem')]
+    // },
+    // {
+    //   code: '<menuitem type="radio" aria-selected />',
+    //   errors: [getErrorMessage('aria-selected', 'menuitemradio')]
+    // },
+    // {
+    //   code: '<menu type="toolbar" aria-haspopup />',
+    //   errors: [getErrorMessage('aria-haspopup', 'toolbar')]
+    // },
+    // {
+    //   code: '<menu type="toolbar" aria-invalid />',
+    //   errors: [getErrorMessage('aria-invalid', 'toolbar')]
+    // },
+    // {
+    //   code: '<menu type="toolbar" aria-expanded />',
+    //   errors: [getErrorMessage('aria-expanded', 'toolbar')]
+    // },
+    // {
+    //   code: '<link href="#" aria-invalid />',
+    //   errors: [getErrorMessage('aria-invalid', 'link')]
+    // },
+    // {
+    //   code: '<area href="#" aria-invalid />',
+    //   errors: [getErrorMessage('aria-invalid', 'link')]
+    // },
+    // {
+    //   code: '<a href="#" aria-invalid />',
+    //   errors: [getErrorMessage('aria-invalid', 'link')]
+    // },
+    // {
+    //   code: '<Link href="#" aria-checked />',
+    //   errors: [getErrorMessage('aria-checked', 'link')]
+    // },
+    // {
+    //   code: '<span aria-label />',
+    //   errors: [getErrorMessage('aria-label', 'generic')]
+    // },
+    // {
+    //   code: '<span aria-labelledby />',
+    //   errors: [getErrorMessage('aria-labelledby', 'generic')]
+    // },
+    // {
+    //   code: '<div aria-label />',
+    //   errors: [getErrorMessage('aria-label', 'generic')]
+    // },
+    // {
+    //   code: '<div aria-labelledby />',
+    //   errors: [getErrorMessage('aria-labelledby', 'generic')]
+    // }
+  ]
+})

--- a/tests/role-supports-aria-props.js
+++ b/tests/role-supports-aria-props.js
@@ -1,4 +1,15 @@
 // @ts-check
+
+// Tests in this file were adapted from https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/__tests__/src/rules/role-supports-aria-props-test.js, which was authored by Ethan Cohen and is distributed under the MIT license as follows:
+//
+// The MIT License (MIT) Copyright (c) 2016 Ethan Cohen
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 const rule = require('../lib/rules/role-supports-aria-props')
 const RuleTester = require('eslint').RuleTester
 
@@ -91,9 +102,6 @@ ruleTester.run('role-supports-aria-props', rule, {
     // this will have global
     {code: '<link aria-checked />'},
 
-    // IMG TESTS - no implicit role
-    {code: '<img alt="" aria-checked />'},
-
     // this will have role of `img`
     {code: '<img alt="foobar" aria-busy />'},
 
@@ -113,9 +121,6 @@ ruleTester.run('role-supports-aria-props', rule, {
     {code: '<menu type="toolbar" aria-live />'},
     {code: '<menu type="toolbar" aria-owns />'},
     {code: '<menu type="toolbar" aria-relevant />'},
-
-    // this will have global
-    {code: '<menu aria-checked />'},
 
     // MENUITEM TESTS
     // when `type="command`, the implicit role is `menuitem`
@@ -370,142 +375,138 @@ ruleTester.run('role-supports-aria-props', rule, {
     {
       code: '<ul aria-expanded />',
       errors: [getErrorMessage('aria-expanded', 'list')]
+    },
+    {
+      code: '<details aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'group')]
+    },
+    {
+      code: '<dialog aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'dialog')]
+    },
+    {
+      code: '<aside aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'complementary')]
+    },
+    {
+      code: '<article aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'article')]
+    },
+    {
+      code: '<body aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'document')]
+    },
+    {
+      code: '<li aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'listitem')]
+    },
+    {
+      code: '<nav aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'navigation')]
+    },
+    {
+      code: '<ol aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'list')]
+    },
+    {
+      code: '<output aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'status')]
+    },
+    {
+      code: '<section aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'region')]
+    },
+    {
+      code: '<tbody aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'rowgroup')]
+    },
+    {
+      code: '<tfoot aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'rowgroup')]
+    },
+    {
+      code: '<thead aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'rowgroup')]
+    },
+    {
+      code: '<input type="radio" aria-invalid />',
+      errors: [getErrorMessage('aria-invalid', 'radio')]
+    },
+    {
+      code: '<input type="radio" aria-selected />',
+      errors: [getErrorMessage('aria-selected', 'radio')]
+    },
+    {
+      code: '<input type="radio" aria-haspopup />',
+      errors: [getErrorMessage('aria-haspopup', 'radio')]
+    },
+    {
+      code: '<input type="checkbox" aria-haspopup />',
+      errors: [getErrorMessage('aria-haspopup', 'checkbox')]
+    },
+    {
+      code: '<input type="reset" aria-invalid />',
+      errors: [getErrorMessage('aria-invalid', 'button')]
+    },
+    {
+      code: '<input type="submit" aria-invalid />',
+      errors: [getErrorMessage('aria-invalid', 'button')]
+    },
+    {
+      code: '<input type="image" aria-invalid />',
+      errors: [getErrorMessage('aria-invalid', 'button')]
+    },
+    {
+      code: '<input type="button" aria-invalid />',
+      errors: [getErrorMessage('aria-invalid', 'button')]
+    },
+    {
+      code: '<menuitem type="command" aria-invalid />',
+      errors: [getErrorMessage('aria-invalid', 'menuitem')]
+    },
+    {
+      code: '<menuitem type="radio" aria-selected />',
+      errors: [getErrorMessage('aria-selected', 'menuitemradio')]
+    },
+    {
+      code: '<menu type="toolbar" aria-haspopup />',
+      errors: [getErrorMessage('aria-haspopup', 'toolbar')]
+    },
+    {
+      code: '<menu type="toolbar" aria-invalid />',
+      errors: [getErrorMessage('aria-invalid', 'toolbar')]
+    },
+    {
+      code: '<menu type="toolbar" aria-expanded />',
+      errors: [getErrorMessage('aria-expanded', 'toolbar')]
+    },
+    {
+      code: '<link href="#" aria-invalid />',
+      errors: [getErrorMessage('aria-invalid', 'link')]
+    },
+    {
+      code: '<area href="#" aria-invalid />',
+      errors: [getErrorMessage('aria-invalid', 'link')]
+    },
+    {
+      code: '<a href="#" aria-invalid />',
+      errors: [getErrorMessage('aria-invalid', 'link')]
+    },
+    {
+      code: '<span aria-label />',
+      errors: [getErrorMessage('aria-label', 'generic')]
+    },
+    {
+      code: '<span aria-labelledby />',
+      errors: [getErrorMessage('aria-labelledby', 'generic')]
+    },
+    {
+      code: '<div aria-label />',
+      errors: [getErrorMessage('aria-label', 'generic')]
+    },
+    {
+      code: '<div aria-labelledby />',
+      errors: [getErrorMessage('aria-labelledby', 'generic')]
     }
-    // {
-    //   code: '<details aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'group')]
-    // },
-    // {
-    //   code: '<dialog aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'dialog')]
-    // },
-    // {
-    //   code: '<aside aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'complementary')]
-    // },
-    // {
-    //   code: '<article aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'article')]
-    // },
-    // {
-    //   code: '<body aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'document')]
-    // },
-    // {
-    //   code: '<li aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'listitem')]
-    // },
-    // {
-    //   code: '<nav aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'navigation')]
-    // },
-    // {
-    //   code: '<ol aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'list')]
-    // },
-    // {
-    //   code: '<output aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'status')]
-    // },
-    // {
-    //   code: '<section aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'region')]
-    // },
-    // {
-    //   code: '<tbody aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'rowgroup')]
-    // },
-    // {
-    //   code: '<tfoot aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'rowgroup')]
-    // },
-    // {
-    //   code: '<thead aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'rowgroup')]
-    // },
-    // {
-    //   code: '<input type="radio" aria-invalid />',
-    //   errors: [getErrorMessage('aria-invalid', 'radio')]
-    // },
-    // {
-    //   code: '<input type="radio" aria-selected />',
-    //   errors: [getErrorMessage('aria-selected', 'radio')]
-    // },
-    // {
-    //   code: '<input type="radio" aria-haspopup />',
-    //   errors: [getErrorMessage('aria-haspopup', 'radio')]
-    // },
-    // {
-    //   code: '<input type="checkbox" aria-haspopup />',
-    //   errors: [getErrorMessage('aria-haspopup', 'checkbox')]
-    // },
-    // {
-    //   code: '<input type="reset" aria-invalid />',
-    //   errors: [getErrorMessage('aria-invalid', 'button')]
-    // },
-    // {
-    //   code: '<input type="submit" aria-invalid />',
-    //   errors: [getErrorMessage('aria-invalid', 'button')]
-    // },
-    // {
-    //   code: '<input type="image" aria-invalid />',
-    //   errors: [getErrorMessage('aria-invalid', 'button')]
-    // },
-    // {
-    //   code: '<input type="button" aria-invalid />',
-    //   errors: [getErrorMessage('aria-invalid', 'button')]
-    // },
-    // {
-    //   code: '<menuitem type="command" aria-invalid />',
-    //   errors: [getErrorMessage('aria-invalid', 'menuitem')]
-    // },
-    // {
-    //   code: '<menuitem type="radio" aria-selected />',
-    //   errors: [getErrorMessage('aria-selected', 'menuitemradio')]
-    // },
-    // {
-    //   code: '<menu type="toolbar" aria-haspopup />',
-    //   errors: [getErrorMessage('aria-haspopup', 'toolbar')]
-    // },
-    // {
-    //   code: '<menu type="toolbar" aria-invalid />',
-    //   errors: [getErrorMessage('aria-invalid', 'toolbar')]
-    // },
-    // {
-    //   code: '<menu type="toolbar" aria-expanded />',
-    //   errors: [getErrorMessage('aria-expanded', 'toolbar')]
-    // },
-    // {
-    //   code: '<link href="#" aria-invalid />',
-    //   errors: [getErrorMessage('aria-invalid', 'link')]
-    // },
-    // {
-    //   code: '<area href="#" aria-invalid />',
-    //   errors: [getErrorMessage('aria-invalid', 'link')]
-    // },
-    // {
-    //   code: '<a href="#" aria-invalid />',
-    //   errors: [getErrorMessage('aria-invalid', 'link')]
-    // },
-    // {
-    //   code: '<Link href="#" aria-checked />',
-    //   errors: [getErrorMessage('aria-checked', 'link')]
-    // },
-    // {
-    //   code: '<span aria-label />',
-    //   errors: [getErrorMessage('aria-label', 'generic')]
-    // },
-    // {
-    //   code: '<span aria-labelledby />',
-    //   errors: [getErrorMessage('aria-labelledby', 'generic')]
-    // },
-    // {
-    //   code: '<div aria-label />',
-    //   errors: [getErrorMessage('aria-label', 'generic')]
-    // },
-    // {
-    //   code: '<div aria-labelledby />',
-    //   errors: [getErrorMessage('aria-labelledby', 'generic')]
-    // }
   ]
 })

--- a/tests/role-supports-aria-props.js
+++ b/tests/role-supports-aria-props.js
@@ -18,9 +18,9 @@ const ruleTester = new RuleTester({
     ecmaVersion: 'latest',
     sourceType: 'module',
     ecmaFeatures: {
-      jsx: true
-    }
-  }
+      jsx: true,
+    },
+  },
 })
 
 function getErrorMessage(attribute, role) {
@@ -343,170 +343,170 @@ ruleTester.run('role-supports-aria-props', rule, {
     {code: '<select aria-expanded />'},
     {code: '<datalist aria-expanded />'},
     {code: '<div role="heading" aria-level />'},
-    {code: '<div role="heading" aria-level="1" />'}
+    {code: '<div role="heading" aria-level="1" />'},
   ],
 
   invalid: [
     // implicit basic checks
     {
       code: '<a href="#" aria-checked />',
-      errors: [getErrorMessage('aria-checked', 'link')]
+      errors: [getErrorMessage('aria-checked', 'link')],
     },
     {
       code: '<area href="#" aria-checked />',
-      errors: [getErrorMessage('aria-checked', 'link')]
+      errors: [getErrorMessage('aria-checked', 'link')],
     },
     {
       code: '<link href="#" aria-checked />',
-      errors: [getErrorMessage('aria-checked', 'link')]
+      errors: [getErrorMessage('aria-checked', 'link')],
     },
     {
       code: '<img alt="foobar" aria-checked />',
-      errors: [getErrorMessage('aria-checked', 'img')]
+      errors: [getErrorMessage('aria-checked', 'img')],
     },
     {
       code: '<menu type="toolbar" aria-checked />',
-      errors: [getErrorMessage('aria-checked', 'toolbar')]
+      errors: [getErrorMessage('aria-checked', 'toolbar')],
     },
     {
       code: '<aside aria-checked />',
-      errors: [getErrorMessage('aria-checked', 'complementary')]
+      errors: [getErrorMessage('aria-checked', 'complementary')],
     },
     {
       code: '<ul aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'list')]
+      errors: [getErrorMessage('aria-expanded', 'list')],
     },
     {
       code: '<details aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'group')]
+      errors: [getErrorMessage('aria-expanded', 'group')],
     },
     {
       code: '<dialog aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'dialog')]
+      errors: [getErrorMessage('aria-expanded', 'dialog')],
     },
     {
       code: '<aside aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'complementary')]
+      errors: [getErrorMessage('aria-expanded', 'complementary')],
     },
     {
       code: '<article aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'article')]
+      errors: [getErrorMessage('aria-expanded', 'article')],
     },
     {
       code: '<body aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'document')]
+      errors: [getErrorMessage('aria-expanded', 'document')],
     },
     {
       code: '<li aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'listitem')]
+      errors: [getErrorMessage('aria-expanded', 'listitem')],
     },
     {
       code: '<nav aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'navigation')]
+      errors: [getErrorMessage('aria-expanded', 'navigation')],
     },
     {
       code: '<ol aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'list')]
+      errors: [getErrorMessage('aria-expanded', 'list')],
     },
     {
       code: '<output aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'status')]
+      errors: [getErrorMessage('aria-expanded', 'status')],
     },
     {
       code: '<section aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'region')]
+      errors: [getErrorMessage('aria-expanded', 'region')],
     },
     {
       code: '<tbody aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'rowgroup')]
+      errors: [getErrorMessage('aria-expanded', 'rowgroup')],
     },
     {
       code: '<tfoot aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'rowgroup')]
+      errors: [getErrorMessage('aria-expanded', 'rowgroup')],
     },
     {
       code: '<thead aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'rowgroup')]
+      errors: [getErrorMessage('aria-expanded', 'rowgroup')],
     },
     {
       code: '<input type="radio" aria-invalid />',
-      errors: [getErrorMessage('aria-invalid', 'radio')]
+      errors: [getErrorMessage('aria-invalid', 'radio')],
     },
     {
       code: '<input type="radio" aria-selected />',
-      errors: [getErrorMessage('aria-selected', 'radio')]
+      errors: [getErrorMessage('aria-selected', 'radio')],
     },
     {
       code: '<input type="radio" aria-haspopup />',
-      errors: [getErrorMessage('aria-haspopup', 'radio')]
+      errors: [getErrorMessage('aria-haspopup', 'radio')],
     },
     {
       code: '<input type="checkbox" aria-haspopup />',
-      errors: [getErrorMessage('aria-haspopup', 'checkbox')]
+      errors: [getErrorMessage('aria-haspopup', 'checkbox')],
     },
     {
       code: '<input type="reset" aria-invalid />',
-      errors: [getErrorMessage('aria-invalid', 'button')]
+      errors: [getErrorMessage('aria-invalid', 'button')],
     },
     {
       code: '<input type="submit" aria-invalid />',
-      errors: [getErrorMessage('aria-invalid', 'button')]
+      errors: [getErrorMessage('aria-invalid', 'button')],
     },
     {
       code: '<input type="image" aria-invalid />',
-      errors: [getErrorMessage('aria-invalid', 'button')]
+      errors: [getErrorMessage('aria-invalid', 'button')],
     },
     {
       code: '<input type="button" aria-invalid />',
-      errors: [getErrorMessage('aria-invalid', 'button')]
+      errors: [getErrorMessage('aria-invalid', 'button')],
     },
     {
       code: '<menuitem type="command" aria-invalid />',
-      errors: [getErrorMessage('aria-invalid', 'menuitem')]
+      errors: [getErrorMessage('aria-invalid', 'menuitem')],
     },
     {
       code: '<menuitem type="radio" aria-selected />',
-      errors: [getErrorMessage('aria-selected', 'menuitemradio')]
+      errors: [getErrorMessage('aria-selected', 'menuitemradio')],
     },
     {
       code: '<menu type="toolbar" aria-haspopup />',
-      errors: [getErrorMessage('aria-haspopup', 'toolbar')]
+      errors: [getErrorMessage('aria-haspopup', 'toolbar')],
     },
     {
       code: '<menu type="toolbar" aria-invalid />',
-      errors: [getErrorMessage('aria-invalid', 'toolbar')]
+      errors: [getErrorMessage('aria-invalid', 'toolbar')],
     },
     {
       code: '<menu type="toolbar" aria-expanded />',
-      errors: [getErrorMessage('aria-expanded', 'toolbar')]
+      errors: [getErrorMessage('aria-expanded', 'toolbar')],
     },
     {
       code: '<link href="#" aria-invalid />',
-      errors: [getErrorMessage('aria-invalid', 'link')]
+      errors: [getErrorMessage('aria-invalid', 'link')],
     },
     {
       code: '<area href="#" aria-invalid />',
-      errors: [getErrorMessage('aria-invalid', 'link')]
+      errors: [getErrorMessage('aria-invalid', 'link')],
     },
     {
       code: '<a href="#" aria-invalid />',
-      errors: [getErrorMessage('aria-invalid', 'link')]
+      errors: [getErrorMessage('aria-invalid', 'link')],
     },
     {
       code: '<span aria-label />',
-      errors: [getErrorMessage('aria-label', 'generic')]
+      errors: [getErrorMessage('aria-label', 'generic')],
     },
     {
       code: '<span aria-labelledby />',
-      errors: [getErrorMessage('aria-labelledby', 'generic')]
+      errors: [getErrorMessage('aria-labelledby', 'generic')],
     },
     {
       code: '<div aria-label />',
-      errors: [getErrorMessage('aria-label', 'generic')]
+      errors: [getErrorMessage('aria-label', 'generic')],
     },
     {
       code: '<div aria-labelledby />',
-      errors: [getErrorMessage('aria-labelledby', 'generic')]
-    }
-  ]
+      errors: [getErrorMessage('aria-labelledby', 'generic')],
+    },
+  ],
 })

--- a/tests/utils/object-map.js
+++ b/tests/utils/object-map.js
@@ -1,0 +1,180 @@
+// @ts-check
+const ObjectMap = require('../../lib/utils/object-map')
+const {describe, it} = require('mocha')
+const expect = require('chai').expect
+
+describe('ObjectMap', function () {
+  it('constructs an ObjectMap', function () {
+    const objectMap = new ObjectMap()
+    expect(objectMap instanceof ObjectMap).to.be.true
+  })
+
+  it('extends Map', function () {
+    const objectMap = new ObjectMap()
+    expect(objectMap instanceof Map).to.be.true
+  })
+
+  it('populates data from constructor argument', function () {
+    const iterable = [[{name: 'form'}, ['form']]]
+    const objectMap = new ObjectMap(iterable)
+    expect(Array.from(objectMap.entries())).to.deep.equal(iterable)
+  })
+
+  it('clears data', function () {
+    const iterable = [[{name: 'form'}, ['form']]]
+    const objectMap = new ObjectMap(iterable)
+    objectMap.clear()
+    expect(Array.from(objectMap.entries())).to.be.empty
+  })
+
+  it('deletes data that exists', function () {
+    const iterable = [[{name: 'form'}, ['form']]]
+    const objectMap = new ObjectMap(iterable)
+    const returnValue = objectMap.delete({name: 'form'})
+    expect(Array.from(objectMap.entries())).to.be.empty
+    expect(returnValue).to.be.true
+  })
+
+  it('doesn’t delete data that doesn’t exist', function () {
+    const iterable = [[{name: 'form'}, ['form']]]
+    const objectMap = new ObjectMap(iterable)
+    const returnValue = objectMap.delete({name: ''})
+    expect(Array.from(objectMap.entries())).to.deep.equal(iterable)
+    expect(returnValue).to.be.false
+  })
+
+  it('lists entries that exist', function () {
+    const iterable = [
+      [{name: 'form'}, ['form']],
+      [{name: 'span'}, ['generic']]
+    ]
+    const objectMap = new ObjectMap(iterable)
+    const iterator = objectMap.entries()
+    expect(typeof iterator[Symbol.iterator]).to.equal('function')
+    expect(iterator.next()).to.deep.equal({value: iterable[0], done: false})
+    expect(iterator.next()).to.deep.equal({value: iterable[1], done: false})
+    expect(iterator.next()).to.deep.equal({value: undefined, done: true})
+  })
+
+  it('doesn’t list entries that don’t exist', function () {
+    const objectMap = new ObjectMap()
+    const iterator = objectMap.entries()
+    expect(typeof iterator[Symbol.iterator]).to.equal('function')
+    expect(iterator.next()).to.deep.equal({value: undefined, done: true})
+  })
+
+  it('finds key that exists', function () {
+    const iterable = [[{name: 'form'}, ['form']]]
+    const objectMap = new ObjectMap(iterable)
+    expect(objectMap.has({name: 'form'})).to.be.true
+  })
+
+  it('finds key that exists in a different order', function () {
+    const iterable = [[{name: 'form', attributes: [{name: 'action', value: 'POST'}]}, ['form']]]
+    const objectMap = new ObjectMap(iterable)
+    expect(objectMap.has({attributes: [{value: 'POST', name: 'action'}], name: 'form'})).to.be.true
+  })
+
+  it('doesn’t find key that doesn’t exist', function () {
+    const iterable = [[{name: 'form'}, ['form']]]
+    const objectMap = new ObjectMap(iterable)
+    expect(objectMap.has({name: ''})).to.be.false
+  })
+
+  it('doesn’t find key when none exist', function () {
+    const objectMap = new ObjectMap()
+    expect(objectMap.has({name: ''})).to.be.false
+  })
+
+  it('calls callback for each datum', function () {
+    const iterable = [
+      [{name: 'form'}, ['form']],
+      [{name: 'span'}, ['generic']]
+    ]
+    const objectMap = new ObjectMap(iterable)
+    const values = []
+    const keys = []
+    // eslint-disable-next-line github/array-foreach
+    objectMap.forEach((value, key) => {
+      values.push(value)
+      keys.push(key)
+    })
+    expect(values).to.deep.equal([['form'], ['generic']])
+    expect(keys).to.deep.equal([{name: 'form'}, {name: 'span'}])
+  })
+
+  it('finds value given key that exists', function () {
+    const iterable = [[{name: 'form'}, ['form']]]
+    const objectMap = new ObjectMap(iterable)
+    expect(objectMap.get({name: 'form'})).to.deep.equal(['form'])
+  })
+
+  it('finds value given key that exists in a different order', function () {
+    const iterable = [[{name: 'form', attributes: [{name: 'action', value: 'POST'}]}, ['form']]]
+    const objectMap = new ObjectMap(iterable)
+    expect(objectMap.get({attributes: [{value: 'POST', name: 'action'}], name: 'form'})).to.deep.equal(['form'])
+  })
+
+  it('doesn’t find value given key that doesn’t exist', function () {
+    const iterable = [[{name: 'form'}, ['form']]]
+    const objectMap = new ObjectMap(iterable)
+    expect(objectMap.get({name: ''})).to.be.undefined
+  })
+
+  it('doesn’t find value when none exist', function () {
+    const objectMap = new ObjectMap()
+    expect(objectMap.get({name: ''})).to.be.undefined
+  })
+
+  it('lists keys', function () {
+    const iterable = [
+      [{name: 'form'}, ['form']],
+      [{name: 'span'}, ['generic']]
+    ]
+    const objectMap = new ObjectMap(iterable)
+    const iterator = objectMap.keys()
+    expect(typeof iterator[Symbol.iterator]).to.equal('function')
+    expect(iterator.next()).to.deep.equal({value: iterable[0][0], done: false})
+    expect(iterator.next()).to.deep.equal({value: iterable[1][0], done: false})
+    expect(iterator.next()).to.deep.equal({value: undefined, done: true})
+  })
+
+  it('sets value when none exist', function () {
+    const key = {name: 'form'}
+    const value = ['form']
+    const objectMap = new ObjectMap()
+    objectMap.set(key, value)
+    expect(Array.from(objectMap.entries())).to.deep.equal([[key, value]])
+  })
+
+  it('sets value when some exist', function () {
+    const iterable = [[{name: 'form'}, ['form']]]
+    const key = {name: 'span'}
+    const value = ['generic']
+    const objectMap = new ObjectMap(iterable)
+    objectMap.set(key, value)
+    expect(Array.from(objectMap.entries())).to.deep.equal([iterable[0], [key, value]])
+  })
+
+  it('replaces value under existing key', function () {
+    const iterable = [[{name: 'form'}, ['form']]]
+    const key = {name: 'form'}
+    const value = ['generic']
+    const objectMap = new ObjectMap(iterable)
+    objectMap.set(key, value)
+    expect(Array.from(objectMap.entries())).to.deep.equal([[key, value]])
+  })
+
+  it('lists values', function () {
+    const iterable = [
+      [{name: 'form'}, ['form']],
+      [{name: 'span'}, ['generic']]
+    ]
+    const objectMap = new ObjectMap(iterable)
+    const iterator = objectMap.values()
+    expect(typeof iterator[Symbol.iterator]).to.equal('function')
+    expect(iterator.next()).to.deep.equal({value: iterable[0][1], done: false})
+    expect(iterator.next()).to.deep.equal({value: iterable[1][1], done: false})
+    expect(iterator.next()).to.deep.equal({value: undefined, done: true})
+  })
+})

--- a/tests/utils/object-map.js
+++ b/tests/utils/object-map.js
@@ -46,7 +46,7 @@ describe('ObjectMap', function () {
   it('lists entries that exist', function () {
     const iterable = [
       [{name: 'form'}, ['form']],
-      [{name: 'span'}, ['generic']]
+      [{name: 'span'}, ['generic']],
     ]
     const objectMap = new ObjectMap(iterable)
     const iterator = objectMap.entries()
@@ -89,7 +89,7 @@ describe('ObjectMap', function () {
   it('calls callback for each datum', function () {
     const iterable = [
       [{name: 'form'}, ['form']],
-      [{name: 'span'}, ['generic']]
+      [{name: 'span'}, ['generic']],
     ]
     const objectMap = new ObjectMap(iterable)
     const values = []
@@ -129,7 +129,7 @@ describe('ObjectMap', function () {
   it('lists keys', function () {
     const iterable = [
       [{name: 'form'}, ['form']],
-      [{name: 'span'}, ['generic']]
+      [{name: 'span'}, ['generic']],
     ]
     const objectMap = new ObjectMap(iterable)
     const iterator = objectMap.keys()
@@ -168,7 +168,7 @@ describe('ObjectMap', function () {
   it('lists values', function () {
     const iterable = [
       [{name: 'form'}, ['form']],
-      [{name: 'span'}, ['generic']]
+      [{name: 'span'}, ['generic']],
     ]
     const objectMap = new ObjectMap(iterable)
     const iterator = objectMap.values()


### PR DESCRIPTION
Fixes https://github.com/github/accessibility/issues/2427

From that issue:
> If you use `<span aria-label="I’m a tooltip!">Info</span>` in Rails, [ERBLint’s NoAriaLabelMisue rule](https://github.com/github/erblint-github/blob/main/docs/rules/accessibility/no-aria-label-misuse-counter.md) will flag it, since `aria-label` is not supported on non-interactive elements like `span`.
> 
> If you use `<span aria-label="I’m a tooltip!">Info</span>` in React, ESLint doesn’t flag it.

This PR adapts the work I did in https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/pull/911 into a custom rule we can use until the upstream `role-suports-aria-props` is updated to flag `<span aria-label="I’m a tooltip!">Info</span>`.