### PR TITLE
drop node 12 / add node 18 to test matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
[I noticed in this PR](https://github.com/github/eslint-plugin-github/pull/368#issuecomment-1366965933) that tests are failing in node 12 but runnign successfully in node 14, 16, and 18.

But I think we should just change the test node matrix to 14, 16, and 18 seeing as [12 is End-of-Life while 18 is LTS](https://github.com/nodejs/release#release-schedule).