### PR TITLE
drop node 12 / add node 18 to test matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14, 16, 18]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Replaces https://github.com/github/eslint-plugin-github/pull/369

[I noticed in this PR](https://github.com/github/eslint-plugin-github/pull/368#issuecomment-1366965933) that tests are failing in node 12 but running successfully in node 14, 16, and 18.

Given that [node 12 is End-of-Life while 18 is LTS](https://github.com/nodejs/release#release-schedule), I think we should just drop testing again 12.

I also added node 18 as that is current LTS.