### PR TITLE
Bump eslint-plugin-jsx-a11y to 6.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,5 +93,8 @@ This config will be interpreted in the following way:
 
 #### Accessibility-focused rules (prefixed with a11y)
 
-- [No Generic Link Text](./docs/rules/a11y-no-generic-link-text.md)
 - [Role Supports ARIA Props](./docs/rules/role-supports-aria-props.md)
+
+##### Deprecated
+
+- [No Generic Link Text](./docs/rules/a11y-no-generic-link-text.md)

--- a/docs/rules/a11y-no-generic-link-text.md
+++ b/docs/rules/a11y-no-generic-link-text.md
@@ -1,4 +1,6 @@
-# No Generic Link Text
+# No Generic Link Text [Deprecated]
+
+_This rule has been deprecated in favor of `anchor-ambiguous-text` in `eslint-plugin-jsx-a11y`._
 
 ## Rule Details
 

--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -8,7 +8,7 @@ module.exports = {
   plugins: ['github', 'jsx-a11y'],
   extends: ['plugin:jsx-a11y/recommended'],
   rules: {
-    'github/a11y-no-generic-link-text': 'error',
+    'github/a11y-no-generic-link-text': 'off',
     'github/role-supports-aria-props': 'error',
     'jsx-a11y/role-supports-aria-props': 'off',
   },

--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -8,8 +8,14 @@ module.exports = {
   plugins: ['github', 'jsx-a11y'],
   extends: ['plugin:jsx-a11y/recommended'],
   rules: {
-    'github/a11y-no-generic-link-text': 'off',
+    'jsx-a11y/role-supports-aria-props': 'off', // Override with github/role-supports-aria-props until https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/910 is resolved
     'github/role-supports-aria-props': 'error',
-    'jsx-a11y/role-supports-aria-props': 'off',
+    'jsx-a11y/no-aria-hidden-on-focusable': 'error',
+    'jsx-a11y/anchor-ambiguous-text': [
+      'error',
+      {
+        words: ['this', 'more', 'read here', 'read more'],
+      },
+    ],
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-i18n-text": "^1.0.1",
         "eslint-plugin-import": "^2.25.2",
-        "eslint-plugin-jsx-a11y": "^6.6.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-no-only-tests": "^3.0.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-rule-documentation": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-i18n-text": "^1.0.1",
     "eslint-plugin-import": "^2.25.2",
-    "eslint-plugin-jsx-a11y": "^6.6.0",
+    "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-no-only-tests": "^3.0.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-rule-documentation": ">=1.0.0",


### PR DESCRIPTION
This PR bumps the `eslint-plugin-jsx-a11y` dependency from 6.6.0 to 6.7.1 which includes new rules and bug fixes.

Check out the [CHANGELOG for eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/CHANGELOG.md#changelog).

This update includes a new rule `anchor-ambiguous-text` which can replace our custom `a11y-no-generic-link-text`. 
Any recs for how to deprecate the rule? I've just marked the rule as deprecated. 