### PR TITLE
Update react.js to turn `jsx-a11y/no-autofocus` off

### DIFF
--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -12,6 +12,7 @@ module.exports = {
     'github/a11y-aria-label-is-well-formatted': 'error',
     'github/role-supports-aria-props': 'error',
     'jsx-a11y/no-aria-hidden-on-focusable': 'error',
+    'jsx-a11y/no-autofocus': 'off',
     'jsx-a11y/anchor-ambiguous-text': [
       'error',
       {


### PR DESCRIPTION
This is a follow-up to [Staff-only issue](https://github.com/github/accessibility/issues/2927).

There are legitimate uses of `autofocus`. While `autofocus` can easily be misused, we want to rely on other tools like an axe rule to surface those issues rather than code linting. This PR makes it so we turn the [jsx-a11y/no-autofocus](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-autofocus.md) rule which is on as part of the recommended rulesets, off by default. 