### PR TITLE
Ignore calls to a method named innerText

### DIFF
--- a/lib/rules/no-innerText.js
+++ b/lib/rules/no-innerText.js
@@ -12,6 +12,10 @@ module.exports = {
   create(context) {
     return {
       MemberExpression(node) {
+        // If the member expression is part of a call expression like `.innerText()` then it is not the same
+        // as the `Element.innerText` property, and should not trigger a warning
+        if (node.parent.type === 'CallExpression') return
+
         if (node.property && node.property.name === 'innerText') {
           context.report({
             meta: {

--- a/tests/no-innerText.js
+++ b/tests/no-innerText.js
@@ -11,6 +11,10 @@ ruleTester.run('no-innerText', rule, {
     {
       code: 'document.querySelector("js-flash-text").textContent = "bar"',
     },
+    {
+      // This is unrelated to the `HTMLElement.innerText` property, and should not trigger a warning
+      code: 'var text = element.textContent()',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
This removes a false positive for the `github/no-innerText` rule where we flag calls to methods that happen to have the name `innerText` which are unrelated to the `Element.innerText` property. As I understand the spirit of this rule, we are trying to prevent developers from directly manipulating the `innerText` property, rather than ban usage of the property name `innerText` altogether.

In our specific case, we are referencing the Playwright [`Locator.innerText` method](https://playwright.dev/docs/api/class-locator#locator-inner-text) which is related to `Element.innerText`, but is not the same thing. The automatic fixer broke these tests when saving the file, as our tests were written with `innerText` in mind specifically so we could assert things that `textContent` couldn't.

---

To fix this, I modified the rule to return early if the `MemberExpression` is a child of a `CallExpression`. Example of the two related ASTs in screenshot below:

![A screenshot of a browser window, where the left half contains a JavaScript code sample with an invalid member access and assignment to innerText, and a valid code sample which calls a method called innerText, and the right half of the screen shows the corresponding Abstract Syntax Tree (AST) for that code. The first example shows that the MemberExpression node is nested under an AssignmentExpression, while the valid code sample MemberExpression is nested under a CallExpression.](https://github.com/github/eslint-plugin-github/assets/1514176/8c47e97a-cd6b-476e-97b2-1c4f530afd62)


