### PR TITLE
Use `getLiteralPropValue` for sr-only class

### DIFF
--- a/lib/rules/a11y-no-visually-hidden-interactive-element.js
+++ b/lib/rules/a11y-no-visually-hidden-interactive-element.js
@@ -1,4 +1,4 @@
-const {getProp, getPropValue} = require('jsx-ast-utils')
+const {getProp, getLiteralPropValue} = require('jsx-ast-utils')
 const {getElementType} = require('../utils/get-element-type')
 const {generateObjSchema} = require('eslint-plugin-jsx-a11y/lib/util/schemas')
 
@@ -32,9 +32,12 @@ const checkIfInteractiveElement = (context, node) => {
 const checkIfVisuallyHiddenAndInteractive = (context, options, node, isParentVisuallyHidden) => {
   const {className, componentName} = options
   if (node.type === 'JSXElement') {
-    const classes = getPropValue(getProp(node.openingElement.attributes, 'className'))
+    const classes = getLiteralPropValue(getProp(node.openingElement.attributes, 'className'))
     const isVisuallyHiddenElement = node.openingElement.name.name === componentName
-    const hasSROnlyClass = typeof classes !== 'undefined' && classes.includes(className)
+    let hasSROnlyClass = false
+    if (classes != null) {
+      hasSROnlyClass = classes.includes(className)
+    }
     let isHidden = false
     if (hasSROnlyClass || isVisuallyHiddenElement || !!isParentVisuallyHidden) {
       if (checkIfInteractiveElement(context, node)) {

--- a/tests/a11y-no-visually-hidden-interactive-element.js
+++ b/tests/a11y-no-visually-hidden-interactive-element.js
@@ -23,6 +23,9 @@ ruleTester.run('a11y-no-visually-hidden-interactive-element', rule, {
     {code: "<span className='sr-only'>Text</span>;"},
     {code: "<button className='other'>Submit</button>"},
     {code: "<input className='sr-only' />"},
+    {
+      code: "<Foo className={({isOn}) => { return isOn || isOnProps ? `${className} selected`.trim() : className ?? ''}}/>",
+    },
     {code: "<a className='other show-on-focus'>skip to main content</a>"},
     {code: '<button>Submit</button>'},
     {


### PR DESCRIPTION
We caught a scenario where `getPropValue(getProp(node.openingElement.attributes, 'className'))` returns a function.

Example code:

```tsx
<Foo className={({isOn}) => { return isOn || isOnProps ? `${className} selected`.trim() : className ?? ''}}/>
```

Since `getPropValue` will return a function in this case, the `classes.includes` call ends up throwing an error.

This PR updates the logic to use `getLiteralPropValue`and moves around the logic.