### PR TITLE
Bug: Don't fallback to checking implicit role if `role` is set

### DIFF
--- a/lib/utils/get-role.js
+++ b/lib/utils/get-role.js
@@ -46,7 +46,8 @@ function getRole(context, node) {
   const explicitRole = getLiteralPropValue(getProp(node.attributes, 'role'))
   if (explicitRole) {
     return explicitRole
-  } else if (getProp(node.attributes, 'role')) { // If role is set to anything other than a literal prop
+  } else if (getProp(node.attributes, 'role')) {
+    // If role is set to anything other than a literal prop
     return undefined
   }
 

--- a/lib/utils/get-role.js
+++ b/lib/utils/get-role.js
@@ -46,6 +46,8 @@ function getRole(context, node) {
   const explicitRole = getLiteralPropValue(getProp(node.attributes, 'role'))
   if (explicitRole) {
     return explicitRole
+  } else if (getProp(node.attributes, 'role')) { // If role is set to anything other than a literal prop
+    return undefined
   }
 
   // Assemble a key for looking-up the element’s role in the `elementRolesMap`

--- a/tests/a11y-role-supports-aria-props.js
+++ b/tests/a11y-role-supports-aria-props.js
@@ -29,6 +29,18 @@ function getErrorMessage(attribute, role) {
 
 ruleTester.run('a11y-role-supports-aria-props', rule, {
   valid: [
+    {
+      code: `
+      <div
+        id={id}
+        role={
+          sectionHasHeader && rowIndex.row === 0 ? 'presentation' : 'option'
+        }
+        aria-label={this.props.ariaLabel}
+      >
+        {children}
+      </div>`,
+    },
     {code: '<Foo bar />'},
     {code: '<div />'},
     {code: '<div id="main" />'},

--- a/tests/utils/get-role.js
+++ b/tests/utils/get-role.js
@@ -13,8 +13,8 @@ describe('getRole', function () {
   })
 
   it('returns undefined when role is set to non-literal expression', function () {
-    // <Box role={isNavigationOpen ? 'generic' : 'navigation'} />
-    const node = mockJSXOpeningElement('Box', [
+    // <div role={isNavigationOpen ? 'generic' : 'navigation'} />
+    const node = mockJSXOpeningElement('div', [
       mockJSXConditionalAttribute('role', 'isNavigationOpen', 'generic', 'navigation'),
     ])
     expect(getRole({}, node)).to.equal(undefined)


### PR DESCRIPTION
Currently, when `role` is set to anything other than a literal prop, the rest of the code runs and grabs the implicit role.

As a result, even with something like:

```
      <div
        id={id}
        role={
          sectionHasHeader && rowIndex.row === 0 ? 'presentation' : 'option'
        }
        aria-label={this.props.ariaLabel}
      >

```
where we would not expect the `a11y-role-supports-props` to raise anything, the code might assume that the implicit role is that of a `<div>` and is generic, and will flag an error.

Instead, when `role` is explicitly set but is NOT a literal prop, we should return `undefined`. 
