### PR TITLE
Update no-then.md

### DIFF
--- a/docs/rules/no-then.md
+++ b/docs/rules/no-then.md
@@ -35,7 +35,7 @@ function getProcessedData(url) {
 async function countProcessedData(url) {
   const data = await downloadData(url);
   return data.length
-```
+}
 
 ```js
 async function getProcessedData(url) {

--- a/docs/rules/no-then.md
+++ b/docs/rules/no-then.md
@@ -36,6 +36,7 @@ async function countProcessedData(url) {
   const data = await downloadData(url);
   return data.length
 }
+```
 
 ```js
 async function getProcessedData(url) {

--- a/docs/rules/no-then.md
+++ b/docs/rules/no-then.md
@@ -13,9 +13,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/asy
 👎 Examples of **incorrect** code for this rule:
 
 ```js
+function countData(url) {
+  return downloadData(url).then(data => {
+    return data.length
+  })
+}
+```
+
+```js
 function getProcessedData(url) {
   return downloadData(url).catch(e => {
     console.log('Error occurred!', e)
+    return null;
   })
 }
 ```
@@ -23,15 +32,19 @@ function getProcessedData(url) {
 👍 Examples of **correct** code for this rule:
 
 ```js
+async function countProcessedData(url) {
+  const data = await downloadData(url);
+  return data.length
+```
+
+```js
 async function getProcessedData(url) {
-  let v
   try {
-    v = await downloadData(url)
+    return await downloadData(url)
   } catch (e) {
-    console.log('Error occurred!', e)
-    return
+    console.log('Error occurred!', e);
+    return null;
   }
-  return v
 }
 ```
 


### PR DESCRIPTION
The 'improved code' after linting was unnecessarily complex introducing a named variable across multiple lines for no reason which made it look better to keep using `then`. A bit surprising.

Previous catch example was code which didn't differentiate between failing case (which is now a deliberate null) and undefined case (which is often the result of an error).

Also the previous catch example was the only example for a rule which is called 'no-then' and therefore the failing example didn't use 'then' either.