### PR TITLE
fix `a11y-svg-has-accessible-name` considering whitespace JSXText

### DIFF
--- a/lib/rules/a11y-svg-has-accessible-name.js
+++ b/lib/rules/a11y-svg-has-accessible-name.js
@@ -17,8 +17,9 @@ module.exports = {
         if (elementType !== 'svg') return
 
         // Check if there is a nested title element that is the first non-whitespace child of the `<svg>`
-        const childrenWithoutWhitespace = node.parent.children
-          ?.filter(({type, value}) => type === 'JSXText' ? value.trim() !== '' : type !== 'JSXText')
+        const childrenWithoutWhitespace = node.parent.children?.filter(({type, value}) =>
+          type === 'JSXText' ? value.trim() !== '' : type !== 'JSXText',
+        )
 
         const hasNestedTitleAsFirstChild =
           childrenWithoutWhitespace?.[0]?.type === 'JSXElement' &&

--- a/lib/rules/a11y-svg-has-accessible-name.js
+++ b/lib/rules/a11y-svg-has-accessible-name.js
@@ -18,7 +18,7 @@ module.exports = {
 
         // Check if there is a nested title element that is the first non-whitespace child of the `<svg>`
         const childrenWithoutWhitespace = node.parent.children
-          ?.filter(({type, value}) => (type === 'JSXText' && value.trim() !== '') || type !== 'JSXText')
+          ?.filter(({type, value}) => type === 'JSXText' ? value.trim() !== '' : type !== 'JSXText')
 
         const hasNestedTitleAsFirstChild =
           childrenWithoutWhitespace?.[0]?.type === 'JSXElement' &&

--- a/lib/rules/a11y-svg-has-accessible-name.js
+++ b/lib/rules/a11y-svg-has-accessible-name.js
@@ -16,10 +16,13 @@ module.exports = {
         const elementType = getElementType(context, node)
         if (elementType !== 'svg') return
 
-        // Check if there is a nested title element that is the first child of the `<svg>`
+        // Check if there is a nested title element that is the first non-whitespace child of the `<svg>`
+        const childrenWithoutWhitespace = node.parent.children
+          ?.filter(({type, value}) => (type === 'JSXText' && value.trim() !== '') || type !== 'JSXText')
+
         const hasNestedTitleAsFirstChild =
-          node.parent.children?.[0]?.type === 'JSXElement' &&
-          node.parent.children?.[0]?.openingElement?.name?.name === 'title'
+          childrenWithoutWhitespace?.[0]?.type === 'JSXElement' &&
+          childrenWithoutWhitespace?.[0]?.openingElement?.name?.name === 'title'
 
         // Check if `aria-label` or `aria-labelledby` is set
         const hasAccessibleName = hasProp(node.attributes, 'aria-label') || hasProp(node.attributes, 'aria-labelledby')

--- a/tests/a11y-svg-has-accessible-name.js
+++ b/tests/a11y-svg-has-accessible-name.js
@@ -20,6 +20,12 @@ ruleTester.run('a11y-svg-has-accessible-name', rule, {
       code: "<svg height='100' width='100'><title>Circle with a black outline and red fill</title><circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/></svg>",
     },
     {
+      code: `<svg height='100' width='100'>
+              <title>Circle with a black outline and red fill</title>
+              <circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/>
+            </svg>`,
+    },
+    {
       code: "<svg aria-label='Circle with a black outline and red fill' height='100' width='100'><circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/></svg>",
     },
     {


### PR DESCRIPTION
Hello!

This PR fixes an issue I encountered with `a11y-svg-has-accessible-name`. I'm not sure if it's relevant to any "vanilla" use-cases of this plugin, eslint and/or react. My stack is probably very different (deno, fresh, preact) from many users of this plugin and the sole reason I encounter this issue (it's probably Preact, right?), but this PR shouldn't introduce any breaking change to "normal" users.

In my case, the issue was the following:

```jsx
const Test = () => {
	return (
		<svg>
			<title>Title</title>
		</svg>
	)
};

export default Test.
```

Even though I added a title element here, this plugin errored `a11y-svg-has-accessible-name`. After inspecting how this rule is implemented, I saw that it checks if the first child is of type `JSXElement` and `openingElement?.name?.name === 'title'`.

For some reason the JSX parser, whichever it is in my case, inserts a node of type `JSXText` with a value of `\n\t\t\t` as the first child of the `svg` element. I get where it's coming from, since there is actual whitespace in my source code, but I feel like whichever parser does this, should just ignore whitespace here. Maybe this is an upstream issue, but this PR, which filters these empty nodes out before checking, seemed like a quicker fix.