### PR TITLE
Fix bug in `getElementType` logic 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
   extends: [require.resolve('./lib/configs/recommended'), 'plugin:eslint-plugin/all'],
   plugins: ['eslint-plugin'],
   rules: {
+    'import/extensions': 'off',
     'import/no-commonjs': 'off',
     'filenames/match-regex': 'off',
     'i18n-text/no-en': 'off',

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [18]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [18, 20]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18]
 
     steps:
       - uses: actions/checkout@v4

--- a/lib/utils/get-element-type.js
+++ b/lib/utils/get-element-type.js
@@ -17,15 +17,20 @@ function getElementType(context, node, lazyElementCheck = false) {
   // check if the node contains a polymorphic prop
   const polymorphicPropName = settings?.github?.polymorphicPropName ?? 'as'
 
-  const rawElement = elementType(node)
+  let checkConditionalMap = true
 
-  if (getProp(node.attributes, polymorphicPropName)) {
-    return getLiteralPropValue(getProp(node.attributes, polymorphicPropName)) ?? rawElement
-  } else if (settings?.github?.components?.[rawElement]) {
-    return settings.github.components[rawElement]
-  } else {
-    return rawElement
+  const prop = getProp(node.attributes, polymorphicPropName)
+  const literalPropValue = getLiteralPropValue(getProp(node.attributes, polymorphicPropName))
+  if (prop && !literalPropValue) {
+    checkConditionalMap = false
   }
+  const rawElement = getLiteralPropValue(getProp(node.attributes, polymorphicPropName)) ?? elementType(node)
+
+  // if a component configuration does not exists, return the raw element
+  if (!settings?.github?.components?.[rawElement]) return rawElement
+
+  // check if the default component is also defined in the configuration
+  return checkConditionalMap ? settings.github.components[rawElement] : rawElement
 }
 
 module.exports = {getElementType}

--- a/lib/utils/get-element-type.js
+++ b/lib/utils/get-element-type.js
@@ -17,10 +17,11 @@ function getElementType(context, node, lazyElementCheck = false) {
   // check if the node contains a polymorphic prop
   const polymorphicPropName = settings?.github?.polymorphicPropName ?? 'as'
 
-  let checkConditionalMap = true
-
   const prop = getProp(node.attributes, polymorphicPropName)
   const literalPropValue = getLiteralPropValue(getProp(node.attributes, polymorphicPropName))
+  let checkConditionalMap = true
+
+  // If the prop is not a literal and we cannot determine it, don't fall back to the conditional map value, if it exists
   if (prop && !literalPropValue) {
     checkConditionalMap = false
   }

--- a/lib/utils/get-element-type.js
+++ b/lib/utils/get-element-type.js
@@ -16,15 +16,16 @@ function getElementType(context, node, lazyElementCheck = false) {
 
   // check if the node contains a polymorphic prop
   const polymorphicPropName = settings?.github?.polymorphicPropName ?? 'as'
-  const rawElement = getLiteralPropValue(getProp(node.attributes, polymorphicPropName)) ?? elementType(node)
 
-  // if a component configuration does not exists, return the raw element
-  if (!settings?.github?.components?.[rawElement]) return rawElement
+  const rawElement = elementType(node)
 
-  const defaultComponent = settings.github.components[rawElement]
-
-  // check if the default component is also defined in the configuration
-  return defaultComponent ? defaultComponent : defaultComponent
+  if (getProp(node.attributes, polymorphicPropName)) {
+    return getLiteralPropValue(getProp(node.attributes, polymorphicPropName)) ?? rawElement
+  } else if (settings?.github?.components?.[rawElement]) {
+    return settings.github.components[rawElement]
+  } else {
+    return rawElement
+  }
 }
 
 module.exports = {getElementType}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:eslint-docs": "npm run update:eslint-docs -- --check",
     "lint:js": "eslint .",
     "pretest": "mkdir -p node_modules/ && ln -fs $(pwd) node_modules/",
-    "test": "npm run eslint-check && npm run lint && mocha tests/**/*.js tests/",
+    "test": "npm run eslint-check && npm run lint && mocha tests/**/*.js tests/**/*.mjs",
     "update:eslint-docs": "eslint-doc-generator"
   },
   "repository": {

--- a/tests/utils/get-element-type.mjs
+++ b/tests/utils/get-element-type.mjs
@@ -64,14 +64,15 @@ describe('getElementType', function () {
     expect(getElementType({}, node)).to.equal('Box')
   })
 
-  it('returns raw type when polymorphic prop is set to component, and not the mapped value', function () {
-    // <Box as={Link} />
+  it('returns raw type when polymorphic prop is set to component even when there is a mapped value', function () {
+    // <Box as={isNavigationOpen ? 'generic' : 'navigation'} />
     const setting = mockSetting({
       Box: 'div',
     })
 
-    // eslint-disable-next-line no-undef
-    const node = mockJSXOpeningElement('Box', [mockJSXAttribute('as', Link)])
+    const node = mockJSXOpeningElement('Box', [
+      mockJSXConditionalAttribute('as', 'isNavigationOpen', 'generic', 'navigation'),
+    ])
     expect(getElementType(setting, node)).to.equal('Box')
   })
 })

--- a/tests/utils/get-element-type.mjs
+++ b/tests/utils/get-element-type.mjs
@@ -62,7 +62,6 @@ describe('getElementType', function () {
   })
 
   it('returns raw type when polymorphic prop is set to non-literal expression even with component setting', function () {
-    // <Box as={isNavigationOpen ? 'generic' : 'navigation'} />
     const setting = mockSetting({
       Box: 'div',
     })

--- a/tests/utils/get-element-type.mjs
+++ b/tests/utils/get-element-type.mjs
@@ -63,4 +63,15 @@ describe('getElementType', function () {
     ])
     expect(getElementType({}, node)).to.equal('Box')
   })
+
+  it('returns raw type when polymorphic prop is set to component, and not the mapped value', function () {
+    // <Box as={Link} />
+    const setting = mockSetting({
+      Box: 'div',
+    })
+
+    // eslint-disable-next-line no-undef
+    const node = mockJSXOpeningElement('Box', [mockJSXAttribute('as', Link)])
+    expect(getElementType(setting, node)).to.equal('Box')
+  })
 })

--- a/tests/utils/get-element-type.mjs
+++ b/tests/utils/get-element-type.mjs
@@ -1,10 +1,8 @@
 import {expect} from 'chai'
-import {getElementType} from '../../lib/utils/get-element-type'
-import {mockJSXAttribute, mockJSXConditionalAttribute, mockJSXOpeningElement} from './mocks'
+import {getElementType} from '../../lib/utils/get-element-type.js'
+import {mockJSXAttribute, mockJSXConditionalAttribute, mockJSXOpeningElement} from './mocks.js'
 
-const mocha = require('mocha')
-const describe = mocha.describe
-const it = mocha.it
+import {describe, it} from 'mocha'
 
 function mockSetting(componentSetting = {}) {
   return {

--- a/tests/utils/get-element-type.mjs
+++ b/tests/utils/get-element-type.mjs
@@ -1,7 +1,6 @@
 import {expect} from 'chai'
 import {getElementType} from '../../lib/utils/get-element-type.js'
 import {mockJSXAttribute, mockJSXConditionalAttribute, mockJSXOpeningElement} from './mocks.js'
-
 import {describe, it} from 'mocha'
 
 function mockSetting(componentSetting = {}) {
@@ -62,12 +61,11 @@ describe('getElementType', function () {
     expect(getElementType({}, node)).to.equal('Box')
   })
 
-  it('returns raw type when polymorphic prop is set to component even when there is a mapped value', function () {
+  it('returns raw type when polymorphic prop is set to non-literal expression even with component setting', function () {
     // <Box as={isNavigationOpen ? 'generic' : 'navigation'} />
     const setting = mockSetting({
       Box: 'div',
     })
-
     const node = mockJSXOpeningElement('Box', [
       mockJSXConditionalAttribute('as', 'isNavigationOpen', 'generic', 'navigation'),
     ])

--- a/tests/utils/get-role.mjs
+++ b/tests/utils/get-role.mjs
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
-import {getRole} from '../../lib/utils/get-role'
-import {mockJSXAttribute, mockJSXConditionalAttribute, mockJSXOpeningElement} from './mocks'
+import {getRole} from '../../lib/utils/get-role.js'
+import {mockJSXAttribute, mockJSXConditionalAttribute, mockJSXOpeningElement} from './mocks.js'
 import {describe, it} from 'mocha'
 
 describe('getRole', function () {

--- a/tests/utils/object-map.mjs
+++ b/tests/utils/object-map.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import {expect} from 'chai'
-import ObjectMap from '../../lib/utils/object-map'
+import ObjectMap from '../../lib/utils/object-map.js'
 import {describe, it} from 'mocha'
 
 describe('ObjectMap', function () {


### PR DESCRIPTION
This PR fixes a few issues:

#### 1. Fixing bug in `getElementType` logic

```.ts
const mapping = {
  'Box': 'div'
}
```

```.tsx
<Box as={something} />
```

will be interpreted as `div`. Currently the linter will check the mapping if it is unable to interpret the polymorphic value. However, it should not do that because that is not a correct interpretation.

#### 2. Fixing mjs tests that aren't running

I noticed the tests in `utils` aren't running even when calling `npm run test`.

This seems related to [this change](https://github.com/github/eslint-plugin-github/commit/5c76fdec19b2f9cbed3856f6fbdf59fdc85ad7ff) where the tests were converted to `.mjs`, but the `.mjs` tests aren't actually running. When I fixed the command, the tests are being targeted. The test will not run properly without the `.js` extension.  


#### 3. Drops node 14 support

Drops node 14 support per [slack thread](https://github.slack.com/archives/CMZ4DC9BL/p1715874890704489)!

#### 4. Adds node 16 support