### PR TITLE
Bump node 14 to node 18 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 18
           registry-url: https://registry.npmjs.org/
           cache: npm
       - run: npm ci


### PR DESCRIPTION
We recently decided to drop node 14 and 16 support..

I forgot to remove the node version from the publish workflow resulting in [publish workflow failure](https://github.com/github/eslint-plugin-github/actions/runs/9162643140), so this PR drops it and upgrades the version to node 18.