### PR TITLE
Provide `no-redundant-roles` exception for `rowgroup`

### DIFF
--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -42,5 +42,13 @@ module.exports = {
         fieldset: ['radiogroup', 'presentation'],
       },
     ],
+    'jsx-a11y/no-redundant-roles': [
+      'error',
+      {
+        nav: ['navigation'], // default in eslint-plugin-jsx-a11y
+        tbody: ['rowgroup'],
+        thead: ['rowgroup'],
+      },
+    ],
   },
 }


### PR DESCRIPTION
Relates to: https://github.com/github/accessibility/issues/5304

Follow-up to: https://github.com/github/accessibility/discussions/4921

## What
This PR adds an exception so that the `no-redundant-roles` rule does not flag:
*  `<thead role="rowgroup">`
*  `<tbody role="rowgroup">`

## Why
We have determined this markup is necessary in some scenarios to improve screen reader semantics, and should not be flagged as redundant. Because these are the only reported false positive instances, it does not seem worth turning the rule off completely. If there are other special scenarios reported, we should add it as an exception here in this config.

See [specific example in primer/react](https://github.com/primer/react/blob/8cd6007e589d33fd89a1ab2a93547b9977e274b2/src/DataTable/Table.tsx#L298).