### PR TITLE
Actions/Node Updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     // Update 'VARIANT' to pick a Node version: 16, 14, 12.
     // Append -bullseye or -buster to pin to an OS version.
     // Use -bullseye variants on local arm64/Apple Silicon.
-    "args": {"VARIANT": "16"}
+    "args": {"VARIANT": "22"}
   },
 
   // Set *default* container specific settings.json values on container create.

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -19,6 +23,6 @@ jobs:
       - run: npm version ${TAG_NAME} --git-tag-version=false
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-      - run: npm whoami; npm --ignore-scripts publish
+      - run: npm whoami; npm --ignore-scripts publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
       - run: npm ci


### PR DESCRIPTION
Node 22 will be active LTS by the end of the month, so I'd like to update this repo to use Node 22 by default.

* Updated the development container to use Node 22
* Updated Actions to use Node 22
* Update Actions to publish with [provenance](https://docs.npmjs.com/generating-provenance-statements)