### PR TITLE
[Patch] Bumping `eslint-plugin-escompat` plugin to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@typescript-eslint/parser": "^8.0.0",
         "aria-query": "^5.3.0",
         "eslint-config-prettier": ">=8.0.0",
-        "eslint-plugin-escompat": "^3.3.3",
+        "eslint-plugin-escompat": "^3.11.3",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-i18n-text": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@typescript-eslint/parser": "^8.0.0",
     "aria-query": "^5.3.0",
     "eslint-config-prettier": ">=8.0.0",
-    "eslint-plugin-escompat": "^3.3.3",
+    "eslint-plugin-escompat": "^3.11.3",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-i18n-text": "^1.0.1",


### PR DESCRIPTION
There was a fix to the `eslint-plugin-escompat` plugin in [this PR](https://github.com/keithamus/eslint-plugin-escompat/pull/39). Bumping the version used here to capture that fix