### PR TITLE
Update filenames default since it is now in our repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ export default [
 ```
 
 > [!NOTE]
-> If you configured the `filenames/match-regex` rule, please note we have adapted the match regex rule into `eslint-plugin-github` as the original `eslint-filenames-plugin` is no longer maintained and needed an ESLint v9/flat config update. Please update the name to `github/filenames-match-regex` and keep the same configuration. Note, that the default rule is camelCase with one hump. If there are multiple humps like `camelCaseTest.js`, this default rule will error out. Here's an example for this rule with custom configuration:
+> If you configured the `filenames/match-regex` rule, please note we have adapted the match regex rule into `eslint-plugin-github` as the original `eslint-filenames-plugin` is no longer maintained and needed a flat config support update. 
+> 
+> Please update the name to `github/filenames-match-regex`. Please note, the default rule is kebab case or camelCase with one hump. For custom configuration, such as matching for camelCase regex, here's an example:
 >
-> `'github/filenames-match-regex': ['error', '^[a-z0-9-]+(.[a-z0-9-]+)?$']`
+> `'github/filenames-match-regex': ['error', '^([a-z0-9]+)([A-Z][a-z0-9]+)*$'],`
 
 The available configs are:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ export default [
 > [!NOTE]
 > If you configured the `filenames/match-regex` rule, please note we have adapted the match regex rule into `eslint-plugin-github` as the original `eslint-filenames-plugin` is no longer maintained and needed a flat config support update. 
 > 
-> Please update the name to `github/filenames-match-regex`. Please note, the default rule is kebab case or camelCase with one hump. For custom configuration, such as matching for camelCase regex, here's an example:
+> Please update the name to `github/filenames-match-regex`, and note, the default rule is kebab case or camelCase with one hump. For custom configuration, such as matching for camelCase regex, here's an example:
 >
 > `'github/filenames-match-regex': ['error', '^([a-z0-9]+)([A-Z][a-z0-9]+)*$'],`
 

--- a/docs/rules/filenames-match-regex.md
+++ b/docs/rules/filenames-match-regex.md
@@ -4,26 +4,38 @@
 
 ## Rule Details
 
-Rule to ensure that filenames match a convention, with a default of camelCase for ESLint v9+.
+Rule to ensure that filenames match a convention, with a default of kebab case or camelCase with one hump for flat config.
 
 👎 Examples of **incorrect** filename for this default rule:
 
-`file-name.js`
+- `fileNameRule.js`
 
 👍 Examples of **correct** code for this rule:
 
-`fileName.js`
+- `fileName.js`
+- `file-name.js`
 
 ## Options
 
-regex - Regex to match the filename structure. Defaults to camelCase.
+- regex - Regex to match the filename structure. Defaults to kebab case or camelCase with one hump.
 
+Default:
 
 ```json
 {
   "filenames-match-regex": [
     "error",
-    "^[a-z0-9-]+(.[a-z0-9-]+)?$"
+  ]
+}
+```
+
+If you want to add custom regex such as matching all camelCase, this would be the option:
+
+```json
+{
+  'filenames-match-regex': [
+    'error', 
+    '^([a-z0-9]+)([A-Z][a-z0-9]+)*$'
   ]
 }
 ```

--- a/docs/rules/filenames-match-regex.md
+++ b/docs/rules/filenames-match-regex.md
@@ -24,18 +24,18 @@ Default:
 ```json
 {
   "filenames-match-regex": [
-    "error",
+    "error"
   ]
 }
 ```
 
-If you want to add custom regex such as matching all camelCase, this would be the option:
+If you want to add custom regex such as matching all camelCase, add the regex as a string. For example, for camelCase it would look like:
 
 ```json
 {
-  'filenames-match-regex': [
-    'error', 
-    '^([a-z0-9]+)([A-Z][a-z0-9]+)*$'
+  "filenames-match-regex": [
+    "error",
+    "^([a-z0-9]+)([A-Z][a-z0-9]+)*$"
   ]
 }
 ```

--- a/docs/rules/filenames-match-regex.md
+++ b/docs/rules/filenames-match-regex.md
@@ -17,7 +17,7 @@ Rule to ensure that filenames match a convention, with a default of kebab case o
 
 ## Options
 
-- regex - Regex to match the filename structure. Defaults to kebab case or camelCase with one hump.
+regex - Regex to match the filename structure. Defaults to kebab case or camelCase with one hump.
 
 Default:
 

--- a/lib/configs/flat/recommended.js
+++ b/lib/configs/flat/recommended.js
@@ -32,7 +32,7 @@ module.exports = {
     'eslintComments/no-unused-disable': 'error',
     'eslintComments/no-unused-enable': 'error',
     'eslintComments/no-use': ['error', {allow: ['eslint', 'eslint-disable-next-line', 'eslint-env', 'globals']}],
-    'github/filenames-match-regex': ['error', '^[a-z0-9-]+(.[a-z0-9-]+)?$'],
+    'github/filenames-match-regex': 'error',
     'func-style': ['error', 'declaration', {allowArrowFunctions: true}],
     'github/array-foreach': 'error',
     'github/no-implicit-buggy-globals': 'error',

--- a/lib/rules/filenames-match-regex.js
+++ b/lib/rules/filenames-match-regex.js
@@ -25,7 +25,8 @@ module.exports = {
   },
 
   create(context) {
-    const defaultRegexp = /^([a-z0-9]+)([A-Z][a-z0-9]+)*$/g
+    // GitHub's default is kebab case or one hump camel case
+    const defaultRegexp = /^[a-z0-9-]+(.[a-z0-9-]+)?$/
     const conventionRegexp = context.options[0] ? new RegExp(context.options[0]) : defaultRegexp
     const ignoreExporting = context.options[1] ? context.options[1] : false
 

--- a/test-examples/flat/eslint.config.mjs
+++ b/test-examples/flat/eslint.config.mjs
@@ -13,6 +13,7 @@ export default [
       'github/no-then': 'error',
       'github/no-blur': 'error',
       'github/async-preventdefault': 'error',
+      'github/filenames-match-regex': ['error', '^([a-z0-9]+)([A-Z][a-z0-9]+)*$'],
     },
   },
 ]


### PR DESCRIPTION
This is a pull request that updates the filenames default since it is now in our repo. We can make our default to what was once a custom configuration for flat config. 

This way folks can update to their custom regex and our default) won't conflict with that. I've updated the documentation as well. 