### PR TITLE
use single quotes

### DIFF
--- a/lib/rules/async-currenttarget.js
+++ b/lib/rules/async-currenttarget.js
@@ -22,7 +22,7 @@ module.exports = {
             if (scopeDidWait.has(scope)) {
               context.report({
                 node,
-                message: "event.currentTarget inside an async function is error prone",
+                message: 'event.currentTarget inside an async function is error prone',
               })
               break
             }

--- a/lib/rules/async-preventdefault.js
+++ b/lib/rules/async-preventdefault.js
@@ -22,7 +22,7 @@ module.exports = {
             if (scopeDidWait.has(scope)) {
               context.report({
                 node,
-                message: "event.preventDefault() inside an async function is error prone",
+                message: 'event.preventDefault() inside an async function is error prone',
               })
               break
             }


### PR DESCRIPTION
- update two rule messages to use single quotes
  - was causing `prettier` error that caused CI to fail in https://github.com/github/eslint-plugin-github/pull/588