### PR TITLE
Update rules for flat config

### DIFF
--- a/lib/rules/async-currenttarget.js
+++ b/lib/rules/async-currenttarget.js
@@ -11,7 +11,7 @@ module.exports = {
   create(context) {
     const scopeDidWait = new WeakSet()
     const sourceCode = context.sourceCode ?? context.getSourceCode()
-    
+
     return {
       AwaitExpression(node) {
         scopeDidWait.add(sourceCode.getScope ? sourceCode.getScope(node) : context.getScope())

--- a/lib/rules/async-currenttarget.js
+++ b/lib/rules/async-currenttarget.js
@@ -10,14 +10,15 @@ module.exports = {
 
   create(context) {
     const scopeDidWait = new WeakSet()
-
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
+    
     return {
-      AwaitExpression() {
-        scopeDidWait.add(context.getScope())
+      AwaitExpression(node) {
+        scopeDidWait.add(sourceCode.getScope ? sourceCode.getScope(node) : context.getScope())
       },
       MemberExpression(node) {
         if (node.property && node.property.name === 'currentTarget') {
-          let scope = context.getScope()
+          let scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope()
           while (scope) {
             if (scopeDidWait.has(scope)) {
               context.report({

--- a/lib/rules/async-preventdefault.js
+++ b/lib/rules/async-preventdefault.js
@@ -10,14 +10,15 @@ module.exports = {
 
   create(context) {
     const scopeDidWait = new WeakSet()
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
 
     return {
-      AwaitExpression() {
-        scopeDidWait.add(context.getScope())
+      AwaitExpression(node) {
+        scopeDidWait.add(sourceCode.getScope ? sourceCode.getScope(node) : context.getScope())
       },
       CallExpression(node) {
         if (node.callee.property && node.callee.property.name === 'preventDefault') {
-          let scope = context.getScope()
+          let scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope()
           while (scope) {
             if (scopeDidWait.has(scope)) {
               context.report({

--- a/lib/rules/filenames-match-regex.js
+++ b/lib/rules/filenames-match-regex.js
@@ -29,7 +29,7 @@ module.exports = {
     const defaultRegexp = /^[a-z0-9-]+(.[a-z0-9-]+)?$/
     const conventionRegexp = context.options[0] ? new RegExp(context.options[0]) : defaultRegexp
     const ignoreExporting = context.options[1] ? context.options[1] : false
-    
+
     return {
       Program(node) {
         const filename = context.filename ?? context.getFilename()

--- a/lib/rules/filenames-match-regex.js
+++ b/lib/rules/filenames-match-regex.js
@@ -29,10 +29,10 @@ module.exports = {
     const defaultRegexp = /^[a-z0-9-]+(.[a-z0-9-]+)?$/
     const conventionRegexp = context.options[0] ? new RegExp(context.options[0]) : defaultRegexp
     const ignoreExporting = context.options[1] ? context.options[1] : false
-
+    
     return {
       Program(node) {
-        const filename = context.getFilename()
+        const filename = context.filename ?? context.getFilename()
         const absoluteFilename = path.resolve(filename)
         const parsed = parseFilename(absoluteFilename)
         const shouldIgnore = isIgnoredFilename(filename)

--- a/lib/rules/no-useless-passive.js
+++ b/lib/rules/no-useless-passive.js
@@ -32,7 +32,7 @@ module.exports = {
           if (i === -1) return
           const passiveProp = options.properties[i]
           const l = options.properties.length
-          const source = context.getSourceCode()
+          const source = context.sourceCode ?? context.getSourceCode()
           context.report({
             node: passiveProp,
             message: `"${name.value}" event listener is not cancellable and so \`passive: true\` does nothing.`,

--- a/test-examples/flat/eslint.config.mjs
+++ b/test-examples/flat/eslint.config.mjs
@@ -13,7 +13,9 @@ export default [
       'github/no-then': 'error',
       'github/no-blur': 'error',
       'github/async-preventdefault': 'error',
-      'github/filenames-match-regex': ['error', '^([a-z0-9]+)([A-Z][a-z0-9]+)*$'],
+      'github/async-currenttarget': 'error',
+      'github/no-useless-passive': 'error',
+      'github/filenames-match-regex': 'error',
     },
   },
 ]

--- a/test-examples/flat/src/getAttribute.js
+++ b/test-examples/flat/src/getAttribute.js
@@ -12,3 +12,21 @@ document.addEventListener('click', async function (event) {
 
   event.preventDefault()
 })
+
+window.addEventListener(
+  'scroll',
+  () => {
+    console.log('Scroll event fired!')
+  },
+  {passive: true},
+)
+
+document.addEventListener('click', async function (event) {
+  // event.currentTarget will be an HTMLElement
+  const url = event.currentTarget.getAttribute('data-url')
+  const data = await fetch(url)
+
+  // But now, event.currentTarget will be null
+  const text = event.currentTarget.getAttribute('data-text')
+  // ...
+})


### PR DESCRIPTION
Closes: https://github.com/github/eslint-plugin-github/issues/589

This now updates the rules as ESLint has updated the rules API for custom rules: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/

Tested and looks like it's now working as expected:

```
/workspaces/eslint-plugin-github/test-examples/flat/src/forEachTest.js
  1:1  error  Filename 'forEachTest.js' does not match the regex naming convention  github/filenames-match-regex

/workspaces/eslint-plugin-github/test-examples/flat/src/getAttribute.js
  13:3   error  event.preventDefault() inside an async function is error prone                  github/async-preventdefault
  21:4   error  "scroll" event listener is not cancellable and so `passive: true` does nothing  github/no-useless-passive
  30:16  error  event.currentTarget inside an async function is error prone                     github/async-currenttarget
```