### PR TITLE
fix: upgrade eslint-plugin-jsx-a11y

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-i18n-text": "^1.0.1",
         "eslint-plugin-import": "^2.25.2",
-        "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-no-only-tests": "^3.0.0",
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-rule-documentation": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-i18n-text": "^1.0.1",
     "eslint-plugin-import": "^2.25.2",
-    "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-no-only-tests": "^3.0.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-rule-documentation": ">=1.0.0",


### PR DESCRIPTION
While it seems most of the configs have been updated to work with eslint 9, the dependency https://github.com/github/eslint-plugin-github/blob/1b65401f6ede80ecdc0da5398043081cd6e2b8f3/package.json#L47
doesn't have support for flat configs until [v6.10.0](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/releases/tag/v6.10.0).

This means that  it crashes here: https://github.com/github/eslint-plugin-github/blob/1b65401f6ede80ecdc0da5398043081cd6e2b8f3/lib/configs/flat/react.js#L6