### PR TITLE
Update a11y rule config to not flag `role` being set for `ul`

### DIFF
--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -36,7 +36,7 @@ module.exports = {
         nav: ['navigation'], // default in eslint-plugin-jsx-a11y
         tbody: ['rowgroup'],
         thead: ['rowgroup'],
-        ul: ['list'], // In webkit, setting list-style-type: none results in semantics being removed. Need for explicit role.
+        ul: ['list'], // In webkit, setting list-style-type: none results in semantics being removed. Need explicit role.
       },
     ],
   },

--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -36,6 +36,7 @@ module.exports = {
         nav: ['navigation'], // default in eslint-plugin-jsx-a11y
         tbody: ['rowgroup'],
         thead: ['rowgroup'],
+        ul: ['list'] // In webkit, setting list-style-type: none results in semantics being removed. Need for explicit role.
       },
     ],
   },

--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -36,7 +36,7 @@ module.exports = {
         nav: ['navigation'], // default in eslint-plugin-jsx-a11y
         tbody: ['rowgroup'],
         thead: ['rowgroup'],
-        ul: ['list'] // In webkit, setting list-style-type: none results in semantics being removed. Need for explicit role.
+        ul: ['list'], // In webkit, setting list-style-type: none results in semantics being removed. Need for explicit role.
       },
     ],
   },


### PR DESCRIPTION
This PR updates the config for the [no-redundant-roles](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-redundant-roles.md) lint rule.

In webkit, setting `list-style-type: none` results in semantics being removed, so explicit roles are necessary.