### PR TITLE
Add typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "jsx-ast-utils": "^3.3.2",
         "prettier": "^3.0.0",
         "svg-element-attributes": "^1.3.1",
+        "typescript": "^5.7.3",
         "typescript-eslint": "^8.14.0"
       },
       "bin": {
@@ -4478,10 +4479,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "peer": true,
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jsx-ast-utils": "^3.3.2",
     "prettier": "^3.0.0",
     "svg-element-attributes": "^1.3.1",
+    "typescript": "^5.7.3",
     "typescript-eslint": "^8.14.0"
   },
   "prettier": "@github/prettier-config",


### PR DESCRIPTION
Closes: https://github.com/github/eslint-plugin-github/issues/612

It should work if you have `typescript` as a dependency, but we should still have this in our `package.json`.