### PR TITLE
fix: add ESLint v10 to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "npm-run-all": "^4.1.5"
       },
       "peerDependencies": {
-        "eslint": "^8 || ^9"
+        "eslint": "^8 || ^9 || ^10"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "prettier": "@github/prettier-config",
   "browserslist": "extends @github/browserslist-config",
   "peerDependencies": {
-    "eslint": "^8 || ^9"
+    "eslint": "^8 || ^9 || ^10"
   },
   "files": [
     "bin/*",


### PR DESCRIPTION
## Summary

Widens `eslint` peerDependencies from `^8 || ^9` to `^8 || ^9 || ^10`.

All rules already use the modern `context.sourceCode` / `sourceCode.getScope()` APIs with fallbacks for older versions, so no runtime changes are needed. Audited all 5 rule files that reference deprecated context APIs — all already use `??` / ternary fallback patterns.

Closes #680

## Test plan

- [x] All 67 existing tests pass
- [x] ESLint linting passes
- [x] Audited all rule files using deprecated context APIs — all already use fallback patterns