### PR TITLE
Support ESLint 10: widen peer range and fix eslint-comments in flat recommended config

### DIFF
--- a/lib/configs/flat/recommended.js
+++ b/lib/configs/flat/recommended.js
@@ -17,7 +17,7 @@ export default {
   },
   plugins: {
     prettier: prettierPlugin,
-    'eslint-comments': eslintComments,
+    'eslint-comments': fixupPluginRules(eslintComments),
     import: importPlugin,
     'i18n-text': fixupPluginRules(i18nTextPlugin),
     'no-only-tests': noOnlyTestsPlugin,

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "npm-run-all": "^4.1.5"
       },
       "peerDependencies": {
-        "eslint": "^8 || ^9"
+        "eslint": "^8 || ^9 || ^10"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "prettier": "@github/prettier-config",
   "browserslist": "extends @github/browserslist-config",
   "peerDependencies": {
-    "eslint": "^8 || ^9"
+    "eslint": "^8 || ^9 || ^10"
   },
   "files": [
     "bin/*",


### PR DESCRIPTION
Minimum changes needed to support ESlint 10 in github-ui. As part of https://github.com/github/web-systems/issues/5207. 

What changes are proposed: (they were tested as local directories on github-ui locally)

1. Expanded supported ESLint peer range
Changed peerDependencies from ^8 || ^9 to ^8 || ^9 || ^10 in:
[package.json:62](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[package-lock.json:49](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
2. Fixed flat recommended plugin wiring for compatibility
Wrapped eslint-plugin-eslint-comments with @eslint/compat in:
[recommended.js:20](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)