### PR TITLE
714 - Adding jsxA11y plugin support back

### DIFF
--- a/lib/configs/flat/react.js
+++ b/lib/configs/flat/react.js
@@ -14,6 +14,7 @@ export default {
   },
   plugins: {github: fixupPluginRules(github), 'jsx-a11y': jsxA11yPlugin},
   rules: {
+    ...jsxA11yPlugin.flatConfigs.recommended.rules,
     'jsx-a11y/role-supports-aria-props': 'off', // Override with github/a11y-role-supports-aria-props until https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/910 is resolved
     'github/a11y-aria-label-is-well-formatted': 'error',
     'github/a11y-no-visually-hidden-interactive-element': 'error',


### PR DESCRIPTION
Closes https://github.com/github/eslint-plugin-github/issues/714

Adding `...jsxA11yPlugin.flatConfigs.recommended.rules,` at rule level to avoid later override. More details on [714](https://github.com/github/eslint-plugin-github/issues/714)